### PR TITLE
feat: show glTF JSON alongside the 3D model preview

### DIFF
--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfAssetParser.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfAssetParser.kt
@@ -21,6 +21,7 @@ import java.nio.ByteOrder
 object GltfAssetParser {
 
     private val gson = Gson()
+    private val prettyGson = com.google.gson.GsonBuilder().setPrettyPrinting().create()
     
     // GLB constants
     private const val GLB_MAGIC = 0x46546C67 // "glTF" in little-endian
@@ -142,14 +143,81 @@ object GltfAssetParser {
             val gltfJson = gson.fromJson(jsonContent, JsonObject::class.java)
 
             val metadata = extractMetadata(gltfJson, gltfFile.name)
-            
+
             // Log imported assets
             extractAndLogImportedAssets(gltfJson, gltfFile.name)
-            
+
             return metadata
         } catch (e: Exception) {
             println("GLTF Parser: Error parsing GLTF metadata for ${gltfFile.name}: ${e.message}")
             return null
+        }
+    }
+
+    /**
+     * Returns the glTF JSON of a model as a pretty-printed string, or null if it
+     * cannot be read/parsed. For .gltf files this is the file contents; for .glb
+     * files it is the embedded JSON chunk extracted from the binary container.
+     */
+    fun extractGltfJson(file: File): String? {
+        if (!file.exists() || !file.canRead()) {
+            return null
+        }
+        val rawJson = when (file.extension.lowercase()) {
+            "gltf" -> runCatching { file.readText() }.getOrNull()
+            "glb" -> readGlbJsonChunk(file)
+            else -> null
+        } ?: return null
+
+        return prettyPrintJson(rawJson)
+    }
+
+    /**
+     * Reads the JSON chunk from a GLB (binary glTF) container and returns it as a
+     * string, or null if the file is not a valid GLB or the chunk cannot be read.
+     */
+    private fun readGlbJsonChunk(glbFile: File): String? {
+        return try {
+            val actualFileSize = glbFile.length()
+            RandomAccessFile(glbFile, "r").use { raf ->
+                // 12-byte header: magic, version, total length
+                val headerBuffer = ByteArray(12)
+                raf.readFully(headerBuffer)
+                val header = ByteBuffer.wrap(headerBuffer).order(ByteOrder.LITTLE_ENDIAN)
+                if (header.int != GLB_MAGIC) return null
+                header.int // version
+                header.int // total length (unused)
+
+                // 8-byte JSON chunk header: length, type
+                val chunkHeaderBuffer = ByteArray(8)
+                raf.readFully(chunkHeaderBuffer)
+                val chunkHeader = ByteBuffer.wrap(chunkHeaderBuffer).order(ByteOrder.LITTLE_ENDIAN)
+                val jsonChunkLength = chunkHeader.int
+                if (chunkHeader.int != GLB_CHUNK_TYPE_JSON) return null
+
+                val remainingBytes = actualFileSize - 20
+                if (jsonChunkLength < 0 || jsonChunkLength > remainingBytes) return null
+
+                val jsonBytes = ByteArray(jsonChunkLength)
+                raf.readFully(jsonBytes)
+                String(jsonBytes, Charsets.UTF_8).trimEnd('\u0000', ' ')
+            }
+        } catch (e: Exception) {
+            println("GLB Parser: Error reading JSON chunk for ${glbFile.name}: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Pretty-prints a glTF JSON string. Returns the original string unchanged if it
+     * cannot be parsed as JSON, so malformed models still show their raw content.
+     */
+    private fun prettyPrintJson(rawJson: String): String {
+        return try {
+            val element = com.google.gson.JsonParser.parseString(rawJson)
+            prettyGson.toJson(element)
+        } catch (e: Exception) {
+            rawJson
         }
     }
     

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DEditorProvider.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DEditorProvider.kt
@@ -21,7 +21,15 @@ class Model3DEditorProvider : FileEditorProvider, DumbAware {
         project: Project,
         file: VirtualFile
     ): FileEditor {
-        return Model3DEditor(project, file)
+        val preview = Model3DEditor(project, file)
+        // Show the glTF JSON next to the 3D preview (editor/split/preview toggle).
+        // Fall back to a preview-only editor if the JSON cannot be extracted.
+        val jsonEditor = Model3DTextEditorWithPreview.createJsonTextEditor(project, file)
+        return if (jsonEditor != null) {
+            Model3DTextEditorWithPreview(jsonEditor, preview)
+        } else {
+            preview
+        }
     }
 
     override fun getEditorTypeId(): @NonNls String {

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DFileSupport.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DFileSupport.kt
@@ -1,5 +1,6 @@
 package ke.co.coterie.plugins.model3dviewer
 
+import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -24,10 +25,20 @@ object Model3DFileSupport {
     }
 
     /**
+     * Resolves the real 3D model file backing a [FileEditor]. For the JSON split editor
+     * ([Model3DTextEditorWithPreview]) the editor's own file is an in-memory JSON file,
+     * so we resolve the model file from the preview side instead.
+     */
+    fun resolveModelFile(editor: FileEditor?): VirtualFile? = when (editor) {
+        is Model3DTextEditorWithPreview -> editor.modelFile
+        else -> editor?.file
+    }
+
+    /**
      * Returns true when the editor currently in focus holds a supported 3D model file.
      */
     fun isSupportedFileInFocus(project: Project): Boolean {
-        val file = FileEditorManager.getInstance(project).selectedEditor?.file
-        return isSupported(file)
+        val editor = FileEditorManager.getInstance(project).selectedEditor
+        return isSupported(resolveModelFile(editor))
     }
 }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
@@ -1,10 +1,14 @@
 package ke.co.coterie.plugins.model3dviewer
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileEditor.TextEditorWithPreview
 import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.LightVirtualFile
 import java.io.File
@@ -38,22 +42,53 @@ class Model3DTextEditorWithPreview(
         get() = previewEditor.file
 
     companion object {
+        private val JSON_EXTENSIONS = setOf("gltf", "glb")
+        private const val LOADING_PLACEHOLDER = "// Loading glTF JSON…"
+
         /**
-         * Builds a read-only [TextEditor] showing the model's glTF JSON, or null when
-         * the JSON cannot be extracted (in which case the caller should fall back to a
-         * preview-only editor).
+         * Builds a read-only [TextEditor] showing the model's glTF JSON, or null when the
+         * file cannot contain extractable glTF JSON (e.g. .obj), in which case the caller
+         * should fall back to a preview-only editor.
+         *
+         * The editor is returned immediately with a placeholder; the actual JSON is read
+         * and pretty-printed off the EDT and set on the document once ready, so
+         * constructing the editor never blocks the UI on file IO for large models.
          */
         fun createJsonTextEditor(project: Project, file: VirtualFile): TextEditor? {
-            val json = GltfAssetParser.extractGltfJson(File(file.path)) ?: return null
+            if (file.extension?.lowercase() !in JSON_EXTENSIONS) return null
 
             // Present the JSON in a light in-memory file named *.json so it gets JSON
             // syntax highlighting without depending on the JSON plugin module directly.
-            val jsonFile = LightVirtualFile("${file.name}.json", json).apply {
-                isWritable = false
-            }
+            val jsonFile = LightVirtualFile("${file.name}.json", LOADING_PLACEHOLDER)
 
-            val editor = TextEditorProvider.getInstance().createEditor(project, jsonFile)
-            return editor as? TextEditor
+            val editor = TextEditorProvider.getInstance().createEditor(project, jsonFile) as? TextEditor
+                ?: return null
+            // Read-only display without relying on file writability, so we can still
+            // populate the document from the background task below.
+            (editor.editor as? EditorEx)?.isViewer = true
+
+            loadJsonAsync(project, file, editor)
+            return editor
+        }
+
+        private fun loadJsonAsync(project: Project, file: VirtualFile, editor: TextEditor) {
+            ApplicationManager.getApplication().executeOnPooledThread {
+                val text = runCatching { GltfAssetParser.extractGltfJson(File(file.path)) }
+                    .getOrNull()
+                    ?: "// Unable to read glTF JSON for ${file.name}"
+                val normalized = StringUtil.convertLineSeparators(text)
+                ApplicationManager.getApplication().invokeLater(
+                    {
+                        val ed = editor.editor
+                        if (!project.isDisposed && !ed.isDisposed) {
+                            ApplicationManager.getApplication().runWriteAction {
+                                ed.document.setText(normalized)
+                            }
+                        }
+                    },
+                    ModalityState.any()
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
@@ -1,0 +1,59 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.fileEditor.TextEditorWithPreview
+import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.LightVirtualFile
+import java.io.File
+
+/**
+ * Editor that shows the glTF JSON alongside the 3D model preview, mirroring the
+ * editor / split / preview toggle of the Markdown editor.
+ *
+ * The JSON side is a read-only view: for .gltf it is the file contents, for .glb
+ * it is the JSON chunk extracted from the binary container.
+ */
+class Model3DTextEditorWithPreview(
+    textEditor: TextEditor,
+    preview: FileEditor
+) : TextEditorWithPreview(
+    textEditor,
+    preview,
+    "3D Model Viewer",
+    Layout.SHOW_EDITOR_AND_PREVIEW
+) {
+
+    /**
+     * The real 3D model file backing this editor (from the preview side). The text
+     * editor's own file is an in-memory JSON [LightVirtualFile], so status bar widgets
+     * and [Model3DViewerService] use this to know which 3D model is in focus. We do
+     * NOT override [getFile] for this, because the platform ties the text editor's
+     * highlighting session to [getFile]; returning the model file there breaks JSON
+     * highlighting.
+     */
+    val modelFile: VirtualFile?
+        get() = previewEditor.file
+
+    companion object {
+        /**
+         * Builds a read-only [TextEditor] showing the model's glTF JSON, or null when
+         * the JSON cannot be extracted (in which case the caller should fall back to a
+         * preview-only editor).
+         */
+        fun createJsonTextEditor(project: Project, file: VirtualFile): TextEditor? {
+            val json = GltfAssetParser.extractGltfJson(File(file.path)) ?: return null
+
+            // Present the JSON in a light in-memory file named *.json so it gets JSON
+            // syntax highlighting without depending on the JSON plugin module directly.
+            val jsonFile = LightVirtualFile("${file.name}.json", json).apply {
+                isWritable = false
+            }
+
+            val editor = TextEditorProvider.getInstance().createEditor(project, jsonFile)
+            return editor as? TextEditor
+        }
+    }
+}

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DViewerService.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DViewerService.kt
@@ -31,7 +31,8 @@ class Model3DViewerService(project: Project) : Disposable {
         // initial editor selection has already happened (e.g. status bar widgets are
         // created at startup with a 3D model already open), in which case we would
         // otherwise miss it and report no current file.
-        FileEditorManager.getInstance(project).selectedEditor?.file?.let { file ->
+        FileEditorManager.getInstance(project).selectedEditor?.let { editor ->
+            val file = Model3DFileSupport.resolveModelFile(editor)
             if (Model3DFileSupport.isSupported(file)) {
                 currentFile = file
             }
@@ -42,7 +43,7 @@ class Model3DViewerService(project: Project) : Disposable {
             FileEditorManagerListener.FILE_EDITOR_MANAGER,
             object : FileEditorManagerListener {
                 override fun selectionChanged(event: com.intellij.openapi.fileEditor.FileEditorManagerEvent) {
-                    val newFile = event.newFile
+                    val newFile = Model3DFileSupport.resolveModelFile(event.newEditor)
                     if (newFile != null && Model3DFileSupport.isSupported(newFile)) {
                         currentFile = newFile
                         val viewer = viewersByFile[newFile.path]


### PR DESCRIPTION
Adds a Markdown-style split editor (editor/split/preview toggles) that displays the model's glTF JSON on one side and the existing 3D preview on the other. For .gltf the JSON is the file contents; for .glb it is the embedded JSON chunk extracted from the binary container. The JSON view is read-only and rendered in an in-memory *.json file for syntax highlighting.

Status bar widgets and Model3DViewerService now resolve the real model file via Model3DFileSupport.resolveModelFile so the wireframe/animation controls stay visible when the split editor is focused.

Closes #13