### PR TITLE
feat: highlight glTF materials from the JSON caret/selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ View and inspect 3D models directly in your IntelliJ-based IDE.
 - Wireframe mode toggle via status bar
 - Animation playback controls (play/pause)
 - Animation selector for models with multiple animations
+- glTF JSON view alongside the 3D preview (Markdown-style editor / split / preview toggle)
+- Highlight materials in the model by moving the caret or selecting inside the glTF JSON
+  (works for `materials`, `meshes`, and `nodes` entries)
 
 ## Supported File Formats
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,10 @@ dependencies {
         // Add plugin dependencies for compilation here:
         // implementation("com.google.code.gson:gson:2.10.1")
 
+        // Bundled JSON support — needed for JSON PSI (com.intellij.json.psi) used to map
+        // caret/selection in the glTF JSON to the corresponding materials.
+        bundledPlugin("com.intellij.modules.json")
+
         composeUI()
 
     }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfJsonMaterialLocator.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfJsonMaterialLocator.kt
@@ -1,0 +1,72 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.intellij.json.psi.JsonArray
+import com.intellij.json.psi.JsonFile
+import com.intellij.json.psi.JsonObject
+import com.intellij.json.psi.JsonValue
+import com.intellij.openapi.util.TextRange
+
+/**
+ * Maps caret/selection ranges inside the glTF JSON (a [JsonFile]) to the material indices
+ * they refer to, using JSON PSI so the mapping is position-accurate:
+ *
+ *  - inside `materials[i]`                -> material i
+ *  - inside `meshes[m].primitives[p]`     -> that primitive's material
+ *  - inside `meshes[m]` (but no primitive)-> every material used by mesh m
+ *  - inside `nodes[n]`                    -> every material of the mesh node n references
+ *
+ * Ranges spanning several items contribute the union of their materials.
+ */
+object GltfJsonMaterialLocator {
+
+    fun materialsForRanges(
+        psiFile: JsonFile,
+        index: GltfMaterialIndex,
+        ranges: List<TextRange>
+    ): Set<Int> {
+        val root = psiFile.topLevelValue as? JsonObject ?: return emptySet()
+        val out = mutableSetOf<Int>()
+        for (range in ranges) {
+            collect(root, index, range, out)
+        }
+        return out.filterTo(mutableSetOf()) { index.isValidMaterial(it) }
+    }
+
+    private fun collect(
+        root: JsonObject,
+        index: GltfMaterialIndex,
+        range: TextRange,
+        out: MutableSet<Int>
+    ) {
+        arrayItems(root, "materials").forEachIndexed { i, item ->
+            if (item.hits(range)) out.add(i)
+        }
+
+        arrayItems(root, "meshes").forEachIndexed { m, meshItem ->
+            if (!meshItem.hits(range)) return@forEachIndexed
+            val primitives = (meshItem as? JsonObject)?.let { arrayItems(it, "primitives") } ?: emptyList()
+            var matchedPrimitive = false
+            primitives.forEachIndexed { p, primItem ->
+                if (primItem.hits(range)) {
+                    matchedPrimitive = true
+                    index.materialForPrimitive(m, p)?.let { out.add(it) }
+                }
+            }
+            if (!matchedPrimitive) {
+                out.addAll(index.materialsForMesh(m))
+            }
+        }
+
+        arrayItems(root, "nodes").forEachIndexed { n, nodeItem ->
+            if (nodeItem.hits(range)) out.addAll(index.materialsForNode(n))
+        }
+    }
+
+    private fun arrayItems(obj: JsonObject, name: String): List<JsonValue> =
+        (obj.findProperty(name)?.value as? JsonArray)?.valueList ?: emptyList()
+
+    private fun JsonValue.hits(range: TextRange): Boolean {
+        val tr = textRange
+        return if (range.isEmpty) tr.containsOffset(range.startOffset) else tr.intersects(range)
+    }
+}

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfMaterialHighlightListener.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfMaterialHighlightListener.kt
@@ -1,0 +1,66 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.intellij.json.psi.JsonFile
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.event.CaretEvent
+import com.intellij.openapi.editor.event.CaretListener
+import com.intellij.openapi.editor.event.SelectionEvent
+import com.intellij.openapi.editor.event.SelectionListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiDocumentManager
+
+/**
+ * Listens to caret and selection changes in the glTF JSON editor and highlights the
+ * corresponding materials in the 3D preview. The mapping is resolved via
+ * [GltfJsonMaterialLocator]; the material index is built off-EDT once the JSON is loaded
+ * (see [Model3DTextEditorWithPreview.createJsonTextEditor]).
+ */
+class GltfMaterialHighlightListener(
+    private val project: Project,
+    private val modelFile: VirtualFile,
+    private val editor: Editor
+) : CaretListener, SelectionListener {
+
+    @Volatile
+    var materialIndex: GltfMaterialIndex? = null
+
+    private var lastHighlight: Set<Int> = emptySet()
+
+    override fun caretPositionChanged(event: CaretEvent) = update()
+
+    override fun selectionChanged(event: SelectionEvent) = update()
+
+    private fun update() {
+        val index = materialIndex ?: return
+        val materials = ReadAction.compute<Set<Int>, RuntimeException> {
+            val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) as? JsonFile
+                ?: return@compute emptySet()
+            GltfJsonMaterialLocator.materialsForRanges(psiFile, index, currentRanges())
+        }
+
+        if (materials == lastHighlight) return
+        lastHighlight = materials
+
+        val viewer = Model3DViewerService.getInstance(project).getViewerForFile(modelFile) ?: return
+        if (materials.isEmpty()) {
+            viewer.clearHighlight()
+        } else {
+            viewer.highlightMaterials(materials.sorted())
+        }
+    }
+
+    private fun currentRanges(): List<TextRange> {
+        val carets = editor.caretModel.allCarets
+        val selections = carets.mapNotNull { caret ->
+            if (caret.hasSelection()) TextRange(caret.selectionStart, caret.selectionEnd) else null
+        }
+        if (selections.isNotEmpty()) {
+            return selections
+        }
+        // No selection: use the caret position(s) as empty ranges.
+        return carets.map { TextRange(it.offset, it.offset) }
+    }
+}

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfMaterialIndex.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfMaterialIndex.kt
@@ -1,0 +1,74 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+
+/**
+ * Pure lookup helper that resolves glTF structural references (nodes, meshes, primitives)
+ * to the set of material indices they use. Built once from the model's glTF JSON so the
+ * caret/selection listener can translate a JSON location into the materials to highlight.
+ *
+ * A glTF material index equals its position in the top-level `materials` array, so callers
+ * that already know a material index can use it directly; this class handles the indirection
+ * for meshes (mesh -> primitives -> material) and nodes (node -> mesh -> materials).
+ */
+class GltfMaterialIndex private constructor(
+    val materialCount: Int,
+    // meshesToMaterials[m] = ordered materials of mesh m, one entry per primitive (null when
+    // a primitive has no material). Index in the inner list is the primitive index.
+    private val meshPrimitiveMaterials: List<List<Int?>>,
+    // nodeToMesh[n] = mesh index referenced by node n, or null when the node has no mesh.
+    private val nodeToMesh: List<Int?>
+) {
+
+    /** Materials used by every primitive of the given mesh (missing materials skipped). */
+    fun materialsForMesh(meshIndex: Int): Set<Int> {
+        val primitives = meshPrimitiveMaterials.getOrNull(meshIndex) ?: return emptySet()
+        return primitives.filterNotNull().toSet()
+    }
+
+    /** Material used by a specific primitive of a mesh, or null when it has none. */
+    fun materialForPrimitive(meshIndex: Int, primitiveIndex: Int): Int? =
+        meshPrimitiveMaterials.getOrNull(meshIndex)?.getOrNull(primitiveIndex)
+
+    /** Materials used by the mesh a node references (empty when the node has no mesh). */
+    fun materialsForNode(nodeIndex: Int): Set<Int> {
+        val mesh = nodeToMesh.getOrNull(nodeIndex) ?: return emptySet()
+        return materialsForMesh(mesh)
+    }
+
+    /** True when the given index refers to an existing material. */
+    fun isValidMaterial(index: Int): Boolean = index in 0 until materialCount
+
+    companion object {
+        /** Parses the glTF JSON, returning null when it cannot be read as a glTF object. */
+        fun fromJson(json: String): GltfMaterialIndex? {
+            val root = runCatching { JsonParser.parseString(json) }
+                .getOrNull()
+                ?.takeIf { it.isJsonObject }
+                ?.asJsonObject
+                ?: return null
+
+            val materialCount = root.optArray("materials")?.size() ?: 0
+
+            val meshPrimitiveMaterials = root.optArray("meshes")?.map { meshEl ->
+                val mesh = meshEl.takeIf { it.isJsonObject }?.asJsonObject
+                mesh?.optArray("primitives")?.map { primEl ->
+                    primEl.takeIf { it.isJsonObject }?.asJsonObject?.optInt("material")
+                } ?: emptyList()
+            } ?: emptyList()
+
+            val nodeToMesh = root.optArray("nodes")?.map { nodeEl ->
+                nodeEl.takeIf { it.isJsonObject }?.asJsonObject?.optInt("mesh")
+            } ?: emptyList()
+
+            return GltfMaterialIndex(materialCount, meshPrimitiveMaterials, nodeToMesh)
+        }
+
+        private fun JsonObject.optArray(name: String) =
+            get(name)?.takeIf { it.isJsonArray }?.asJsonArray
+
+        private fun JsonObject.optInt(name: String): Int? =
+            get(name)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isNumber }?.asInt
+    }
+}

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
@@ -58,7 +58,7 @@ class Model3DTextEditorWithPreview(
             if (file.extension?.lowercase() !in JSON_EXTENSIONS) return null
 
             // Present the JSON in a light in-memory file named *.json so it gets JSON
-            // syntax highlighting without depending on the JSON plugin module directly.
+            // syntax highlighting and JSON PSI (used to map the caret to materials).
             val jsonFile = LightVirtualFile("${file.name}.json", LOADING_PLACEHOLDER)
 
             val editor = TextEditorProvider.getInstance().createEditor(project, jsonFile) as? TextEditor
@@ -67,16 +67,28 @@ class Model3DTextEditorWithPreview(
             // populate the document from the background task below.
             (editor.editor as? EditorEx)?.isViewer = true
 
-            loadJsonAsync(project, file, editor)
+            // Highlight the corresponding materials in the 3D preview as the caret moves
+            // or the selection changes. Listeners are disposed together with the editor.
+            val highlightListener = GltfMaterialHighlightListener(project, file, editor.editor)
+            editor.editor.caretModel.addCaretListener(highlightListener, editor)
+            editor.editor.selectionModel.addSelectionListener(highlightListener, editor)
+
+            loadJsonAsync(project, file, editor, highlightListener)
             return editor
         }
 
-        private fun loadJsonAsync(project: Project, file: VirtualFile, editor: TextEditor) {
+        private fun loadJsonAsync(
+            project: Project,
+            file: VirtualFile,
+            editor: TextEditor,
+            highlightListener: GltfMaterialHighlightListener
+        ) {
             ApplicationManager.getApplication().executeOnPooledThread {
-                val text = runCatching { GltfAssetParser.extractGltfJson(File(file.path)) }
-                    .getOrNull()
-                    ?: "// Unable to read glTF JSON for ${file.name}"
+                val json = runCatching { GltfAssetParser.extractGltfJson(File(file.path)) }.getOrNull()
+                val text = json ?: "// Unable to read glTF JSON for ${file.name}"
                 val normalized = StringUtil.convertLineSeparators(text)
+                // Build the material index off-EDT from the same JSON we just read.
+                val materialIndex = json?.let { GltfMaterialIndex.fromJson(it) }
                 ApplicationManager.getApplication().invokeLater(
                     {
                         val ed = editor.editor
@@ -84,6 +96,7 @@ class Model3DTextEditorWithPreview(
                             ApplicationManager.getApplication().runWriteAction {
                                 ed.document.setText(normalized)
                             }
+                            highlightListener.materialIndex = materialIndex
                         }
                     },
                     ModalityState.any()

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DViewer.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DViewer.kt
@@ -184,6 +184,16 @@ class Model3DViewer(val project: Project, val file: VirtualFile) : JBCefBrowser(
         executeJavaScript("if (window.selectAnimation) { window.selectAnimation($encodedName); }")
     }
 
+    fun highlightMaterials(indices: List<Int>) {
+        // JSON-encode the index array so it is always a valid JS literal (e.g. [0,2,5]).
+        val encoded = Gson().toJson(indices)
+        executeJavaScript("if (window.highlightMaterials) { window.highlightMaterials($encoded); }")
+    }
+
+    fun clearHighlight() {
+        executeJavaScript("if (window.clearMaterialHighlight) { window.clearMaterialHighlight(); }")
+    }
+
     private fun uploadFile() {
         val client = OkHttpClient()
         println("Virtual File path : ${file.path}")

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DViewerService.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DViewerService.kt
@@ -88,6 +88,11 @@ class Model3DViewerService(project: Project) : Disposable {
     }
 
     /**
+     * Get the viewer registered for a specific file, regardless of the current selection.
+     */
+    fun getViewerForFile(file: VirtualFile): Model3DViewer? = viewersByFile[file.path]
+
+    /**
      * Get the currently selected 3D model file.
      */
     fun getCurrentFile(): VirtualFile? = currentFile

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -74,6 +74,7 @@
     <!-- Product and plugin compatibility requirements.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.compose</depends>
+    <depends>com.intellij.modules.json</depends>
 
     <applicationListeners>
         <listener class="ke.co.coterie.plugins.model3dviewer.Model3DApplicationListener" topic="com.intellij.ide.AppLifecycleListener"/>


### PR DESCRIPTION
Moving the caret into (or selecting) a materials, meshes, or nodes entry in the glTF JSON panel now highlights the corresponding materials in the 3D preview, and clears when the caret leaves a material-bearing region.

- GltfMaterialIndex: pure resolver from glTF JSON to material indices (mesh -> primitives -> material, node -> mesh -> materials).
- GltfJsonMaterialLocator: JSON-PSI mapping of caret/selection ranges to the affected materials.
- GltfMaterialHighlightListener: caret + selection listener wired to the JSON editor, disposed with the editor.
- Model3DViewer.highlightMaterials/clearHighlight bridge to the viewer's new window.highlightMaterials/clearMaterialHighlight (model-viewer setEmissiveFactor, lossless restore). Requires the bundled glbupload WAR.
- Depend on the bundled JSON plugin for JSON PSI.
- Update the bundled viewer WAR and README.