### PR TITLE
Fix marketplace compat and gate merges on plugin verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,8 @@ jobs:
       - name: Build plugin
         run: ./gradlew build
 
-      # Commented out: verifyPlugin requires an IntelliJ IDE instance which may not be available in CI
-      # - name: Verify plugin
-      #   run: ./gradlew verifyPlugin
+      - name: Verify plugin
+        run: ./gradlew verifyPlugin
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,10 @@ jobs:
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: ./gradlew buildPlugin
 
+      - name: Verify plugin
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        run: ./gradlew verifyPlugin
+
       - name: Create GitHub Release
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ View and inspect 3D models directly in your IntelliJ-based IDE.
 
 - **GLB** — Built-in support, works out of the box
 - **GLTF** — Built-in support, automatically bundles referenced assets (textures, binary files)
-  > ⚠️ GLTF support has limited handling for non-self-contained files; external textures may fail to show.
+  
 - **OBJ** — Optional support, enable in **Settings → Tools → 3D Model Viewer**
-  > ⚠️ OBJ support is opt-in because other plugins may also register the `.obj` file extension. Enabling this feature is left to your discretion to avoid potential conflicts. Requires IDE restart after enabling.
+
+> [!WARNING]
+> OBJ support is opt-in because other plugins may also register the `.obj` file extension.
 
 ## Installation
 
@@ -39,7 +41,7 @@ View and inspect 3D models directly in your IntelliJ-based IDE.
 
 ## Usage
 
-1. Open any supported 3D model file (`.glb`, `.gltf`, or `.obj` if enabled)
+1. Open any supported 3D model file (`.glb`, `.gltf`, or `.obj`)
 2. The model will render in the editor tab
 3. Use the status bar widgets at the bottom to:
    - Toggle **Wireframe** mode

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,10 @@ intellijPlatform {
     pluginConfiguration {
         ideaVersion {
             sinceBuild = "252.25557"
+            // This plugin targets the old JCEF API,
+            // compatibility is capped at 253 (2025.3) until
+            // we migrate to the new API.
+            untilBuild = "253.*"
         }
 
         changeNotes = """
@@ -48,6 +52,18 @@ intellijPlatform {
     // Uncomment and configure when ready to publish
     publishing {
         token = providers.environmentVariable("PUBLISH_TOKEN")
+    }
+
+    pluginVerification {
+        ides {
+            recommended()
+        }
+        failureLevel = listOf(
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
+        )
     }
 }
 

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfMaterialHighlightListener.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfMaterialHighlightListener.kt
@@ -1,7 +1,7 @@
 package ke.co.coterie.plugins.model3dviewer
 
 import com.intellij.json.psi.JsonFile
-import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
@@ -9,6 +9,7 @@ import com.intellij.openapi.editor.event.SelectionEvent
 import com.intellij.openapi.editor.event.SelectionListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.util.ThrowableComputable
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
 
@@ -35,11 +36,13 @@ class GltfMaterialHighlightListener(
 
     private fun update() {
         val index = materialIndex ?: return
-        val materials = ReadAction.compute<Set<Int>, RuntimeException> {
-            val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) as? JsonFile
-                ?: return@compute emptySet()
-            GltfJsonMaterialLocator.materialsForRanges(psiFile, index, currentRanges())
-        }
+        val materials = ApplicationManager.getApplication().runReadAction(
+            ThrowableComputable<Set<Int>, RuntimeException> {
+                val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) as? JsonFile
+                    ?: return@ThrowableComputable emptySet()
+                GltfJsonMaterialLocator.materialsForRanges(psiFile, index, currentRanges())
+            }
+        )
 
         if (materials == lastHighlight) return
         lastHighlight = materials

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,10 +28,9 @@
 <ul>
     <li><b>GLB</b> — Built-in support, works out of the box</li>
     <li><b>GLTF</b> — Built-in support, automatically bundles referenced assets (textures, binary files)<br/>
-        <em>⚠️ GLTF support has limited handling for non-self-contained files; external textures may fail to show.</em>
     </li>
     <li><b>OBJ</b> — Optional support, enable in <b>Settings → Tools → 3D Model Viewer</b><br/>
-        <em>⚠️ OBJ support is opt-in because other plugins may also register the .obj file extension. Enabling this feature is left to your discretion to avoid potential conflicts. Requires IDE restart after enabling.</em>
+        <em>OBJ support is opt-in because other plugins may also register the .obj file extension. Requires IDE restart after enabling.</em>
     </li>
 </ul>
 


### PR DESCRIPTION
## What this does

Fixes the JetBrains Marketplace upload scan errors and makes sure the plugin is verified before code lands.

## Changes
- Cap `untilBuild` at `253.*` so the plugin is only checked against IDE builds that ship the old JCEF resource handler API. This clears the AbstractMethodError scan errors (open/read/skip) that only appear on 2026.1.
- Replace the deprecated `ReadAction.compute` call with `runReadAction(ThrowableComputable)`.
- Run `./gradlew verifyPlugin` in CI on every PR.
- Add a verify step to the release workflow so releases cannot publish without passing verification.

## Follow up
Support for the new JCEF open/read/skip API and IntelliJ 2026.1 is tracked separately in the roadmap.