### PR TITLE
chore: auto-generate marketplace change notes from CHANGELOG.md

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,29 @@
+import org.jetbrains.changelog.Changelog
+
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "2.1.20"
     id("org.jetbrains.intellij.platform") version "2.10.2"
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.20"
+    id("org.jetbrains.changelog") version "2.2.1"
 }
 
 group = "ke.co.coterie.plugins"
 version = providers.gradleProperty("pluginVersion").get()
+
+changelog {
+    version = providers.gradleProperty("pluginVersion")
+    groups.empty()
+}
+
+val renderedChangeNotes: String = changelog.run {
+    renderItem(
+        (getOrNull(version.get()) ?: getLatest())
+            .withHeader(false)
+            .withEmptySections(false),
+        Changelog.OutputType.HTML,
+    )
+}
 
 repositories {
     mavenCentral()
@@ -43,9 +60,7 @@ intellijPlatform {
             untilBuild = "253.*"
         }
 
-        changeNotes = """
-            Initial version
-        """.trimIndent()
+        changeNotes = renderedChangeNotes
     }
 
     // JetBrains Marketplace publishing configuration

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -71,6 +71,11 @@
 </ul>
     ]]></description>
 
+    <!-- Change notes are injected automatically at build time from CHANGELOG.md
+         for the current pluginVersion (see the changelog config in build.gradle.kts).
+         Do not edit this by hand. -->
+    <change-notes></change-notes>
+
     <!-- Product and plugin compatibility requirements.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.compose</depends>


### PR DESCRIPTION
## What this does

Makes the JetBrains Marketplace change notes generate themselves from CHANGELOG.md, so every release ships its change list without manual edits.

## How it works
- Applies the `org.jetbrains.changelog` Gradle plugin.
- At build time it renders the current `pluginVersion` section of CHANGELOG.md to HTML and injects it into the plugin.xml `<change-notes>` tag via `patchPluginXml`.
- CHANGELOG.md is already produced by standard-version in the release workflow, so the notes stay in sync with each version bump.
- The notes are rendered eagerly to a plain String to keep the Gradle configuration cache working.

## Notes
- The `<change-notes>` tag in plugin.xml is now populated automatically. Do not edit it by hand.
- Verified with `./gradlew buildPlugin`: the built plugin.xml contains the v1.2.0 feature list with working issue and commit links.