### PR TITLE
chore(ci): add release_as input to override the version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,16 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release_as:
+        description: "Version bump to release. Use 'auto' to derive it from conventional commits, or force a specific bump."
+        type: choice
+        default: auto
+        options:
+          - auto
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -55,8 +65,15 @@ jobs:
       - name: Generate Changelog and Bump Version
         id: changelog
         run: |
-          # Run standard-version to bump version and generate changelog
-          standard-version --releaseCommitMessageFormat "chore(release): {{currentTag}}"
+          # Run standard-version to bump version and generate changelog.
+          # release_as=auto derives the bump from conventional commits;
+          # any other value forces that bump (overriding commit-based detection).
+          RELEASE_AS="${{ github.event.inputs.release_as }}"
+          if [ -n "$RELEASE_AS" ] && [ "$RELEASE_AS" != "auto" ]; then
+            standard-version --releaseCommitMessageFormat "chore(release): {{currentTag}}" --release-as "$RELEASE_AS"
+          else
+            standard-version --releaseCommitMessageFormat "chore(release): {{currentTag}}"
+          fi
           
           # Extract the new version from package.json
           VERSION=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## What this does

Adds a manual control to the release workflow so you can override the version bump instead of always deriving it from conventional commits.

## How it works
- Adds a `release_as` choice input to the release `workflow_dispatch`: `auto`, `patch`, `minor`, `major`. Default is `auto`.
- When set to anything other than `auto`, standard-version runs with `--release-as <value>` to force that bump.
- `auto` keeps the current behaviour (bump derived from commit types).

## Why
A recent `feat:` commit landed on main that would otherwise force a minor bump. With this input you can dispatch the next release as `patch` to keep the version where you want it.