### PR TITLE
fix(viewer): resolve model assets within the project root

### DIFF
--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAssetRegistry.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAssetRegistry.kt
@@ -10,20 +10,42 @@ import java.util.concurrent.ConcurrentHashMap
  * The bundled viewer app is served from plugin resources; the actual model and
  * its relative assets (e.g. a glTF's `Textures/foo.png`) are served straight
  * from disk. To avoid exposing the whole filesystem, each opened model is
- * registered under a random token that resolves only to files *within* the
- * model's own directory, and any path-traversal attempt is rejected.
+ * registered under a random token whose resolution is confined to a single
+ * base directory, and any path-traversal attempt that escapes it is rejected.
+ *
+ * When the model lives inside the open project, the project root is used as the
+ * base and the model is addressed by its project-relative path. This lets a
+ * model reference sibling assets that sit outside its own folder (for example a
+ * glTF whose textures live in a `../glTF/` directory) while still refusing any
+ * path that escapes the project. When the model is outside the project (or no
+ * project root is known), the base falls back to the model's own directory.
  */
 object Model3DAssetRegistry {
 
-    private data class Entry(val baseDir: Path, val mainName: String)
+    private data class Entry(val baseDir: Path, val urlPath: String)
 
     private val entries = ConcurrentHashMap<String, Entry>()
 
-    /** Register a model file, returning a token used to build viewer URLs. */
-    fun register(modelFile: Path): String {
+    /**
+     * Register a model file, returning a token used to build viewer URLs.
+     *
+     * @param modelFile the model file on disk.
+     * @param projectRoot the open project's root directory, if any. When the
+     *   model is inside it, the whole project becomes the traversal boundary.
+     */
+    fun register(modelFile: Path, projectRoot: Path? = null): String {
         val normalized = modelFile.toAbsolutePath().normalize()
+        val root = projectRoot?.toAbsolutePath()?.normalize()
+        val (baseDir, relPath) =
+            if (root != null && normalized != root && normalized.startsWith(root)) {
+                root to root.relativize(normalized)
+            } else {
+                normalized.parent to normalized.fileName
+            }
+        // Path.toString() uses the OS separator; rebuild with '/' for URLs.
+        val urlPath = relPath.joinToString("/") { it.toString() }
         val token = UUID.randomUUID().toString().replace("-", "")
-        entries[token] = Entry(normalized.parent, normalized.fileName.toString())
+        entries[token] = Entry(baseDir, urlPath)
         return token
     }
 
@@ -31,8 +53,11 @@ object Model3DAssetRegistry {
         entries.remove(token)
     }
 
-    /** The main model file name for a token (e.g. `RobotExpressive.glb`). */
-    fun mainName(token: String): String? = entries[token]?.mainName
+    /**
+     * The URL path (relative to the token) that addresses the main model file,
+     * e.g. `RobotExpressive.glb` or `models/gltf/Helmet/glTF/Helmet.gltf`.
+     */
+    fun urlPath(token: String): String? = entries[token]?.urlPath
 
     /**
      * Resolve a relative path against the token's base directory. Returns null

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAssetRegistry.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAssetRegistry.kt
@@ -19,8 +19,27 @@ import java.util.concurrent.ConcurrentHashMap
  * glTF whose textures live in a `../glTF/` directory) while still refusing any
  * path that escapes the project. When the model is outside the project (or no
  * project root is known), the base falls back to the model's own directory.
+ *
+ * Because the project root can be a wide base, resolution is additionally
+ * confined to an allowlist of model/texture/buffer file extensions, so a
+ * malicious model cannot reference arbitrary non-asset project files (source
+ * code, `.env`, `.git` internals, etc.) as external buffers or images.
  */
 object Model3DAssetRegistry {
+
+    /**
+     * File extensions that may be served from disk: model containers, their
+     * geometry/material sidecars, and texture image formats the viewer loads.
+     * Anything else (source code, configs, secrets, extension-less files) is
+     * rejected even when it sits within the traversal base.
+     */
+    private val ALLOWED_ASSET_EXTENSIONS = setOf(
+        // Model containers and sidecars.
+        "gltf", "glb", "obj", "mtl", "stl", "bin",
+        // Texture / image formats.
+        "png", "jpg", "jpeg", "webp", "gif", "bmp", "tga",
+        "ktx2", "ktx", "basis", "dds", "hdr", "exr",
+    )
 
     private data class Entry(val baseDir: Path, val urlPath: String)
 
@@ -61,8 +80,8 @@ object Model3DAssetRegistry {
 
     /**
      * Resolve a relative path against the token's base directory. Returns null
-     * if the token is unknown or the resolved path escapes the base directory
-     * (path-traversal guard).
+     * if the token is unknown, the resolved path escapes the base directory
+     * (path-traversal guard), or the file is not an allowlisted asset type.
      */
     fun resolve(token: String, relativePath: String): Path? {
         val entry = entries[token] ?: return null
@@ -71,6 +90,10 @@ object Model3DAssetRegistry {
         val base = entry.baseDir.toAbsolutePath().normalize()
         val resolved = base.resolve(cleaned).normalize()
         // Must stay within the base directory.
-        return if (resolved.startsWith(base)) resolved else null
+        if (!resolved.startsWith(base)) return null
+        // Must be an asset type we intend to serve (blocks source/configs/secrets).
+        val ext = resolved.fileName.toString().substringAfterLast('.', "").lowercase()
+        if (ext !in ALLOWED_ASSET_EXTENSIONS) return null
+        return resolved
     }
 }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DSchemeHandlerFactory.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DSchemeHandlerFactory.kt
@@ -96,9 +96,9 @@ class Model3DSchemeHandlerFactory : CefSchemeHandlerFactory {
          * Build the viewer URL for an already-registered model token. Encodes
          * the model path + type + wireframe + auto-rotate flags.
          */
-        fun viewerUrl(token: String, mainName: String, wireframe: Boolean, autoRotate: Boolean): String {
-            val type = mainName.substringAfterLast('.', "").lowercase()
-            val modelParam = enc("m/$token/$mainName")
+        fun viewerUrl(token: String, modelPath: String, wireframe: Boolean, autoRotate: Boolean): String {
+            val type = modelPath.substringAfterLast('/').substringAfterLast('.', "").lowercase()
+            val modelParam = enc("m/$token/$modelPath")
             return "http://$VIEWER_HOST/index.html?model=$modelParam&type=$type" +
                 "&wireframe=$wireframe&autorotate=$autoRotate"
         }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DViewer.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DViewer.kt
@@ -208,11 +208,13 @@ class Model3DViewer(val project: Project, val file: VirtualFile) : JBCefBrowser(
         Model3DSchemeHandlerFactory.ensureRegistered()
 
         val modelPath = Paths.get(file.path)
-        assetToken = Model3DAssetRegistry.register(modelPath)
+        val projectRoot = project.basePath?.let { Paths.get(it) }
+        assetToken = Model3DAssetRegistry.register(modelPath, projectRoot)
         val wireframe = Model3DWireframeWidget.wireframeEnabled
+        val modelUrlPath = Model3DAssetRegistry.urlPath(assetToken) ?: modelPath.fileName.toString()
         val serverUrl = Model3DSchemeHandlerFactory.viewerUrl(
             assetToken,
-            modelPath.fileName.toString(),
+            modelUrlPath,
             wireframe,
             Model3DAutoRotateWidget.autoRotateEnabled
         )


### PR DESCRIPTION
## Problem
A model that references assets outside its own folder failed to load them. Example: `models/gltf/DamagedHelmet/glTF-instancing/DamagedHelmetGpuInstancing.gltf` points at its textures via `../glTF/Default_albedo.jpg`. Two things broke:
1. The asset token resolved paths only within the **model's own directory**, so a `../` reference was rejected by the traversal guard.
2. Even without the guard, the browser resolves the relative texture URL against the model URL `m/<token>/<model>`; `../` climbs above `m/<token>/` and **drops the token**, so the request never reaches the right base.

Result: `GLTFLoader: Couldn't load texture`.

## Fix
Register the model under the **project root** rather than its own folder:
- The token now addresses the model by its project-relative path: `m/<token>/<rel-path>/<model>`.
- Parent/sibling references (`../glTF/...`) stay inside the `m/<token>/` space and resolve, while the traversal guard still refuses any path that escapes the project root.
- Falls back to the model's own directory when the model is outside the project or no project root is known.

Changes: `Model3DAssetRegistry` (project-root base + `urlPath(token)`), `Model3DSchemeHandlerFactory.viewerUrl` (multi-segment model path), `Model3DViewer` (passes `project.basePath`).

## Verification
- `./gradlew compileKotlin`: success.
- `./gradlew runIde` with `DamagedHelmetGpuInstancing.gltf` (the `../glTF/*.jpg` case): renders with **zero** failed asset requests in the log.