### PR TITLE
fix: viewer controls for three.js JSON models + cache content sniff

### DIFF
--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DFileSupport.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DFileSupport.kt
@@ -35,10 +35,24 @@ object Model3DFileSupport {
     }
 
     /**
+     * Returns true when [editor] shows a supported 3D model.
+     *
+     * Extension-based [isSupported] can't recognise three.js model JSON (`.json` is
+     * deliberately not a supported extension, so the default JSON editor keeps working
+     * and only one editor provider claims the file). Our own editors, however, are only
+     * ever created for files that a provider already accepted as a 3D model, so their
+     * presence is itself proof of support — and checking the editor type needs no disk IO.
+     */
+    fun isSupportedEditor(editor: FileEditor?): Boolean {
+        if (editor is Model3DTextEditorWithPreview || editor is Model3DEditor) return true
+        return isSupported(resolveModelFile(editor))
+    }
+
+    /**
      * Returns true when the editor currently in focus holds a supported 3D model file.
      */
     fun isSupportedFileInFocus(project: Project): Boolean {
         val editor = FileEditorManager.getInstance(project).selectedEditor
-        return isSupported(resolveModelFile(editor))
+        return isSupportedEditor(editor)
     }
 }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DFileSupport.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DFileSupport.kt
@@ -39,13 +39,18 @@ object Model3DFileSupport {
      *
      * Extension-based [isSupported] can't recognise three.js model JSON (`.json` is
      * deliberately not a supported extension, so the default JSON editor keeps working
-     * and only one editor provider claims the file). Our own editors, however, are only
-     * ever created for files that a provider already accepted as a 3D model, so their
-     * presence is itself proof of support — and checking the editor type needs no disk IO.
+     * and only one editor provider claims the file). For that one case our own editor is
+     * proof of support: [Model3DJsonEditorProvider] only builds it for accepted model
+     * JSON, and checking the editor type needs no disk IO.
+     *
+     * The bypass is scoped to `.json` so every other format still goes through
+     * [isSupported] — in particular OBJ keeps honouring the runtime enable/disable setting.
      */
     fun isSupportedEditor(editor: FileEditor?): Boolean {
-        if (editor is Model3DTextEditorWithPreview || editor is Model3DEditor) return true
-        return isSupported(resolveModelFile(editor))
+        val file = resolveModelFile(editor)
+        if (isSupported(file)) return true
+        return file?.extension?.lowercase() == "json" &&
+            (editor is Model3DTextEditorWithPreview || editor is Model3DEditor)
     }
 
     /**

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DJsonSupport.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DJsonSupport.kt
@@ -1,5 +1,6 @@
 package ke.co.coterie.plugins.model3dviewer
 
+import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
 
 /**
@@ -16,6 +17,13 @@ object Model3DJsonSupport {
     private const val SNIFF_LIMIT = 64 * 1024
     private const val MAX_FILE_SIZE = 64L * 1024 * 1024
 
+    // Caches the sniff result on the file, keyed by modification stamp, so the repeated
+    // FileEditorProvider.accept() calls the platform makes while probing/selecting editors
+    // don't each re-read the file. Invalidated automatically when the stamp changes.
+    private val CACHE_KEY = Key.create<CachedResult>("model3d.isThreeJsModelJson")
+
+    private data class CachedResult(val modificationStamp: Long, val isModel: Boolean)
+
     // The `type` must sit inside the `metadata` object, which keeps ordinary JSON
     // (configs, package.json, schemas that merely contain a "type" key) from matching.
     private val MODEL_METADATA = Regex(
@@ -28,11 +36,19 @@ object Model3DJsonSupport {
         if (file.extension?.lowercase() != "json") return false
         val length = file.length
         if (length <= 0 || length > MAX_FILE_SIZE) return false
-        return try {
+
+        val stamp = file.modificationStamp
+        file.getUserData(CACHE_KEY)?.let { cached ->
+            if (cached.modificationStamp == stamp) return cached.isModel
+        }
+
+        val result = try {
             val bytes = file.inputStream.use { it.readNBytes(SNIFF_LIMIT) }
             MODEL_METADATA.containsMatchIn(String(bytes, Charsets.UTF_8))
         } catch (e: Exception) {
             false
         }
+        file.putUserData(CACHE_KEY, CachedResult(stamp, result))
+        return result
     }
 }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DViewerService.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DViewerService.kt
@@ -32,9 +32,8 @@ class Model3DViewerService(project: Project) : Disposable {
         // created at startup with a 3D model already open), in which case we would
         // otherwise miss it and report no current file.
         FileEditorManager.getInstance(project).selectedEditor?.let { editor ->
-            val file = Model3DFileSupport.resolveModelFile(editor)
-            if (Model3DFileSupport.isSupported(file)) {
-                currentFile = file
+            if (Model3DFileSupport.isSupportedEditor(editor)) {
+                currentFile = Model3DFileSupport.resolveModelFile(editor)
             }
         }
 
@@ -43,8 +42,9 @@ class Model3DViewerService(project: Project) : Disposable {
             FileEditorManagerListener.FILE_EDITOR_MANAGER,
             object : FileEditorManagerListener {
                 override fun selectionChanged(event: com.intellij.openapi.fileEditor.FileEditorManagerEvent) {
-                    val newFile = Model3DFileSupport.resolveModelFile(event.newEditor)
-                    if (newFile != null && Model3DFileSupport.isSupported(newFile)) {
+                    val newEditor = event.newEditor
+                    val newFile = Model3DFileSupport.resolveModelFile(newEditor)
+                    if (newFile != null && Model3DFileSupport.isSupportedEditor(newEditor)) {
                         currentFile = newFile
                         val viewer = viewersByFile[newFile.path]
                         notifyViewerChanged(newFile, viewer)


### PR DESCRIPTION
Follow-up to #46 addressing two review comments.

## 1. Viewer controls now work for three.js JSON models
Status bar widgets (wireframe / auto-rotate / animation) and `Model3DViewerService` recognised models only by extension (`glb/gltf/stl`, plus `obj` when enabled). A three.js JSON model therefore rendered a preview but showed no controls, and `getCurrentViewer()` returned null.

Fix: `Model3DFileSupport.isSupportedEditor()` also treats our own `Model3DTextEditorWithPreview` / `Model3DEditor` as supported — these are only ever created for files a provider already accepted as a 3D model, so it needs no disk IO. The `in-focus` check and `Model3DViewerService` selection tracking use it.

Deliberately **not** adding `json` to `isSupported()`: that method also gates the default (glb/obj) editor provider's `accept()`, and matching `json` there would create a second editor provider for the same file — the multi-provider selection edge case the JSON editor was designed to avoid.

The bundled viewer engine already applies wireframe and publishes animations for the JSON load path, so the now-visible controls are functional (BufferGeometry has no animations, so the animation widget stays hidden as expected).

## 2. Cache the content sniff
`Model3DJsonSupport.isThreeJsModelJson()` read the file head on every call, and it's the whole of `accept()`, which the platform invokes repeatedly while probing/selecting editors. Now cached on the `VirtualFile` keyed by `modificationStamp` (auto-invalidated on edit).

## Verification
`compileKotlin` clean.