### PR TITLE
feat: Model Explorer tool window for glTF/GLB structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ View and inspect 3D models directly in your IntelliJ-based IDE.
 - glTF JSON view alongside the 3D preview (Markdown-style editor / split / preview toggle)
 - Highlight materials in the model by moving the caret or selecting inside the glTF JSON
   (works for `materials`, `meshes`, and `nodes` entries)
+- **Model Explorer** tool window: browse a `.glb` / `.gltf` file's internal structure
+  (asset, scenes, nodes, meshes, materials, accessors, buffer views, images, samplers,
+  animations, …). Double-click a node to jump to it in the glTF JSON, or select a material,
+  mesh or node to highlight it in the 3D preview
 
 ## Supported File Formats
 
@@ -48,6 +52,9 @@ View and inspect 3D models directly in your IntelliJ-based IDE.
    - Toggle **Wireframe** mode
    - **Play/Pause** animations
    - Select animations
+4. For `.glb` / `.gltf` files, open the **Model Explorer** tool window (right stripe, shown while
+   a glTF file is focused) to browse the model's internal structure — double-click a node to jump
+   to it in the glTF JSON, or select a material/mesh/node to highlight it in the preview
 
 ## Screenshots & Videos
 

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfJsonPathLocator.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfJsonPathLocator.kt
@@ -1,0 +1,37 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.intellij.json.psi.JsonArray
+import com.intellij.json.psi.JsonFile
+import com.intellij.json.psi.JsonObject
+import com.intellij.json.psi.JsonValue
+import com.intellij.psi.PsiElement
+
+/**
+ * Resolves a structural [GltfPathSeg] path (as produced by [GltfStructureModel]) to a text
+ * offset inside the *displayed* glTF JSON, using JSON PSI. Because the path is structural
+ * rather than an absolute offset, it stays correct against the pretty-printed JSON the editor
+ * shows even though the tool window tree was built from the raw JSON.
+ */
+object GltfJsonPathLocator {
+
+    /** The offset to navigate to for [path], or null when the path does not resolve. */
+    fun offsetForPath(psiFile: JsonFile, path: List<GltfPathSeg>): Int? {
+        var value: JsonValue = psiFile.topLevelValue ?: return null
+        var target: PsiElement = value
+        for (seg in path) {
+            when (seg) {
+                is GltfPathSeg.Key -> {
+                    val prop = (value as? JsonObject)?.findProperty(seg.name) ?: return null
+                    target = prop
+                    value = prop.value ?: return null
+                }
+                is GltfPathSeg.Index -> {
+                    val element = (value as? JsonArray)?.valueList?.getOrNull(seg.index) ?: return null
+                    target = element
+                    value = element
+                }
+            }
+        }
+        return target.textOffset
+    }
+}

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureAvailabilityListener.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureAvailabilityListener.kt
@@ -1,0 +1,25 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.project.Project
+
+/**
+ * Shows the "Model Explorer" tool window's stripe button only while a `.glb` / `.gltf` file
+ * is in focus. Toggling availability (rather than reading file content) is cheap and safe on
+ * the EDT, mirroring how the status bar widgets react to selection changes.
+ */
+class GltfStructureAvailabilityListener(private val project: Project) : FileEditorManagerListener {
+
+    override fun selectionChanged(event: FileEditorManagerEvent) = updateAvailability()
+
+    override fun fileOpened(
+        source: FileEditorManager,
+        file: com.intellij.openapi.vfs.VirtualFile,
+    ) = updateAvailability()
+
+    private fun updateAvailability() {
+        GltfStructureToolWindow.updateAvailability(project)
+    }
+}

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureModel.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureModel.kt
@@ -202,6 +202,4 @@ object GltfStructureModel {
 
     private fun JsonObject.int(name: String): Int? =
         get(name)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isNumber }?.asInt
-
-    private fun JsonObject.has(name: String): Boolean = get(name) != null
 }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureModel.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureModel.kt
@@ -1,0 +1,207 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+
+/**
+ * A single segment of a structural path into the glTF JSON. Paths are structural (property
+ * name / array index) rather than raw text offsets, so the tool window can resolve them
+ * against the *displayed* (pretty-printed) JSON PSI regardless of the original formatting.
+ */
+sealed interface GltfPathSeg {
+    data class Key(val name: String) : GltfPathSeg
+    data class Index(val index: Int) : GltfPathSeg
+}
+
+/**
+ * One node of the glTF structure tree. Category nodes (e.g. "Materials") group leaf nodes
+ * (e.g. "Material 0 – Steel"). [path] locates the node in the glTF JSON for navigation;
+ * [materialIndices] are the materials to highlight in the 3D preview when the node is
+ * selected (empty when the node maps to no material).
+ */
+class GltfStructureNode(
+    val label: String,
+    val secondary: String? = null,
+    val path: List<GltfPathSeg>? = null,
+    val materialIndices: List<Int> = emptyList(),
+    val children: List<GltfStructureNode> = emptyList(),
+)
+
+/**
+ * Builds a [GltfStructureNode] tree from a glTF JSON document. Pure and side-effect free so
+ * it can run off the EDT. See the glTF 2.0 spec for the meaning of each top-level array.
+ */
+object GltfStructureModel {
+
+    private val COMPONENT_TYPES = mapOf(
+        5120 to "BYTE", 5121 to "UNSIGNED_BYTE", 5122 to "SHORT",
+        5123 to "UNSIGNED_SHORT", 5125 to "UNSIGNED_INT", 5126 to "FLOAT",
+    )
+
+    /** Parses [json], returning the root node (its children are the categories), or null. */
+    fun build(json: String): GltfStructureNode? {
+        val root = runCatching { JsonParser.parseString(json) }.getOrNull()
+            ?.takeIf { it.isJsonObject }?.asJsonObject
+            ?: return null
+
+        val materialIndex = GltfMaterialIndex.fromJson(json)
+        val categories = mutableListOf<GltfStructureNode>()
+
+        root.obj("asset")?.let { categories += assetNode(it) }
+        arrayCategory(root, "scenes", "Scenes") { i, o -> sceneNode(i, o) }?.let { categories += it }
+        arrayCategory(root, "nodes", "Nodes") { i, o -> nodeNode(i, o, materialIndex) }?.let { categories += it }
+        arrayCategory(root, "meshes", "Meshes") { i, o -> meshNode(i, o, materialIndex) }?.let { categories += it }
+        arrayCategory(root, "materials", "Materials") { i, o -> materialNode(i, o) }?.let { categories += it }
+        arrayCategory(root, "accessors", "Accessors") { i, o -> accessorNode(i, o) }?.let { categories += it }
+        arrayCategory(root, "bufferViews", "Buffer Views") { i, o -> bufferViewNode(i, o) }?.let { categories += it }
+        arrayCategory(root, "buffers", "Buffers") { i, o -> bufferNode(i, o) }?.let { categories += it }
+        arrayCategory(root, "textures", "Textures") { i, o -> textureNode(i, o) }?.let { categories += it }
+        arrayCategory(root, "images", "Images") { i, o -> imageNode(i, o) }?.let { categories += it }
+        arrayCategory(root, "samplers", "Samplers") { i, o -> samplerNode(i, o) }?.let { categories += it }
+        arrayCategory(root, "animations", "Animations") { i, o -> animationNode(i, o) }?.let { categories += it }
+        arrayCategory(root, "skins", "Skins") { i, o -> skinNode(i, o) }?.let { categories += it }
+        arrayCategory(root, "cameras", "Cameras") { i, o -> cameraNode(i, o) }?.let { categories += it }
+        stringArrayCategory(root, "extensionsUsed", "Extensions Used")?.let { categories += it }
+        stringArrayCategory(root, "extensionsRequired", "Extensions Required")?.let { categories += it }
+
+        val version = root.obj("asset")?.str("version")
+        val generator = root.obj("asset")?.str("generator")
+        val secondary = listOfNotNull(version?.let { "glTF $it" }, generator).joinToString(" · ").ifEmpty { null }
+        return GltfStructureNode(label = "glTF", secondary = secondary, children = categories)
+    }
+
+    private fun assetNode(asset: JsonObject): GltfStructureNode {
+        val children = buildList {
+            asset.str("version")?.let { add(leaf("version", it, listOf(GltfPathSeg.Key("asset"), GltfPathSeg.Key("version")))) }
+            asset.str("generator")?.let { add(leaf("generator", it, listOf(GltfPathSeg.Key("asset"), GltfPathSeg.Key("generator")))) }
+            asset.str("copyright")?.let { add(leaf("copyright", it, listOf(GltfPathSeg.Key("asset"), GltfPathSeg.Key("copyright")))) }
+            asset.str("minVersion")?.let { add(leaf("minVersion", it, listOf(GltfPathSeg.Key("asset"), GltfPathSeg.Key("minVersion")))) }
+        }
+        return GltfStructureNode("Asset", asset.str("version")?.let { "glTF $it" }, listOf(GltfPathSeg.Key("asset")), children = children)
+    }
+
+    private fun sceneNode(i: Int, o: JsonObject): GltfStructureNode {
+        val nodes = o.arr("nodes")?.size() ?: 0
+        return leaf(o.name(i, "Scene"), "$nodes root node(s)".takeIf { nodes > 0 }, path("scenes", i))
+    }
+
+    private fun nodeNode(i: Int, o: JsonObject, mi: GltfMaterialIndex?): GltfStructureNode {
+        val mesh = o.int("mesh")
+        val secondary = when {
+            mesh != null -> "mesh $mesh"
+            o.has("camera") -> "camera ${o.int("camera")}"
+            o.arr("children") != null -> "${o.arr("children")!!.size()} child node(s)"
+            else -> null
+        }
+        return leaf(o.name(i, "Node"), secondary, path("nodes", i), mi?.materialsForNode(i)?.sorted() ?: emptyList())
+    }
+
+    private fun meshNode(i: Int, o: JsonObject, mi: GltfMaterialIndex?): GltfStructureNode {
+        val prims = o.arr("primitives")?.size() ?: 0
+        return leaf(o.name(i, "Mesh"), "$prims primitive(s)", path("meshes", i), mi?.materialsForMesh(i)?.sorted() ?: emptyList())
+    }
+
+    private fun materialNode(i: Int, o: JsonObject): GltfStructureNode {
+        val bits = buildList {
+            o.str("alphaMode")?.let { add(it) }
+            if (o.get("doubleSided")?.asBoolean == true) add("double-sided")
+        }
+        return leaf(o.name(i, "Material"), bits.joinToString(", ").ifEmpty { null }, path("materials", i), listOf(i))
+    }
+
+    private fun accessorNode(i: Int, o: JsonObject): GltfStructureNode {
+        val type = o.str("type")
+        val comp = o.int("componentType")?.let { COMPONENT_TYPES[it] ?: it.toString() }
+        val count = o.int("count")
+        val secondary = listOfNotNull(listOfNotNull(type, comp).joinToString("/").ifEmpty { null }, count?.let { "×$it" })
+            .joinToString(" ").ifEmpty { null }
+        return leaf("Accessor $i", secondary, path("accessors", i))
+    }
+
+    private fun bufferViewNode(i: Int, o: JsonObject): GltfStructureNode =
+        leaf("Buffer View $i", o.int("byteLength")?.let { "${it} bytes" }, path("bufferViews", i))
+
+    private fun bufferNode(i: Int, o: JsonObject): GltfStructureNode {
+        val secondary = listOfNotNull(o.int("byteLength")?.let { "$it bytes" }, o.str("uri")?.let { uriLabel(it) })
+            .joinToString(" · ").ifEmpty { null }
+        return leaf("Buffer $i", secondary, path("buffers", i))
+    }
+
+    private fun textureNode(i: Int, o: JsonObject): GltfStructureNode {
+        val secondary = listOfNotNull(o.int("source")?.let { "source $it" }, o.int("sampler")?.let { "sampler $it" })
+            .joinToString(", ").ifEmpty { null }
+        return leaf("Texture $i", secondary, path("textures", i))
+    }
+
+    private fun imageNode(i: Int, o: JsonObject): GltfStructureNode {
+        val label = o.str("name") ?: o.str("uri")?.let { uriLabel(it) } ?: "Image $i"
+        val secondary = listOfNotNull(o.str("mimeType"), o.int("bufferView")?.let { "bufferView $it" })
+            .joinToString(", ").ifEmpty { null }
+        return leaf(label, secondary, path("images", i))
+    }
+
+    private fun samplerNode(i: Int, o: JsonObject): GltfStructureNode =
+        leaf("Sampler $i", listOfNotNull(o.int("magFilter")?.let { "mag $it" }, o.int("minFilter")?.let { "min $it" })
+            .joinToString(", ").ifEmpty { null }, path("samplers", i))
+
+    private fun animationNode(i: Int, o: JsonObject): GltfStructureNode =
+        leaf(o.name(i, "Animation"), o.arr("channels")?.let { "${it.size()} channel(s)" }, path("animations", i))
+
+    private fun skinNode(i: Int, o: JsonObject): GltfStructureNode =
+        leaf(o.name(i, "Skin"), o.arr("joints")?.let { "${it.size()} joint(s)" }, path("skins", i))
+
+    private fun cameraNode(i: Int, o: JsonObject): GltfStructureNode =
+        leaf(o.name(i, "Camera"), o.str("type"), path("cameras", i))
+
+    // ---- helpers -------------------------------------------------------------------
+
+    private fun arrayCategory(
+        root: JsonObject,
+        key: String,
+        label: String,
+        leafOf: (Int, JsonObject) -> GltfStructureNode,
+    ): GltfStructureNode? {
+        val array = root.arr(key)?.takeIf { it.size() > 0 } ?: return null
+        val children = array.mapIndexedNotNull { i, el ->
+            (el as? JsonObject ?: el.takeIf { it.isJsonObject }?.asJsonObject)?.let { leafOf(i, it) }
+        }
+        return GltfStructureNode("$label (${array.size()})", path = listOf(GltfPathSeg.Key(key)), children = children)
+    }
+
+    private fun stringArrayCategory(root: JsonObject, key: String, label: String): GltfStructureNode? {
+        val array = root.arr(key)?.takeIf { it.size() > 0 } ?: return null
+        val children = array.mapIndexedNotNull { i, el ->
+            el.takeIf { it.isJsonPrimitive }?.asString?.let { leaf(it, null, path(key, i)) }
+        }
+        return GltfStructureNode("$label (${array.size()})", path = listOf(GltfPathSeg.Key(key)), children = children)
+    }
+
+    private fun leaf(
+        label: String,
+        secondary: String?,
+        path: List<GltfPathSeg>?,
+        materialIndices: List<Int> = emptyList(),
+    ) = GltfStructureNode(label, secondary, path, materialIndices)
+
+    private fun path(key: String, index: Int) = listOf(GltfPathSeg.Key(key), GltfPathSeg.Index(index))
+
+    private fun uriLabel(uri: String): String =
+        if (uri.startsWith("data:")) "embedded" else uri.substringAfterLast('/')
+
+    private fun JsonObject.name(index: Int, kind: String): String = str("name") ?: "$kind $index"
+
+    private fun JsonObject.obj(name: String): JsonObject? =
+        get(name)?.takeIf { it.isJsonObject }?.asJsonObject
+
+    private fun JsonObject.arr(name: String): JsonArray? =
+        get(name)?.takeIf { it.isJsonArray }?.asJsonArray
+
+    private fun JsonObject.str(name: String): String? =
+        get(name)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isString }?.asString
+
+    private fun JsonObject.int(name: String): Int? =
+        get(name)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isNumber }?.asInt
+
+    private fun JsonObject.has(name: String): Boolean = get(name) != null
+}

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.wm.ToolWindow
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.ui.ColoredTreeCellRenderer
 import com.intellij.ui.DoubleClickListener
@@ -44,7 +43,6 @@ import javax.swing.tree.TreeSelectionModel
  */
 class GltfStructurePanel(
     private val project: Project,
-    private val toolWindow: ToolWindow,
 ) : com.intellij.openapi.ui.SimpleToolWindowPanel(true, true), Disposable {
 
     private val treeModel = DefaultTreeModel(null)

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
@@ -1,0 +1,205 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.intellij.icons.AllIcons
+import com.intellij.json.psi.JsonFile
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.DoubleClickListener
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.ui.tree.TreeUtil
+import java.awt.event.MouseEvent
+import java.io.File
+import javax.swing.JTree
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.DefaultTreeModel
+import javax.swing.tree.TreePath
+import javax.swing.tree.TreeSelectionModel
+
+/**
+ * Content of the "Model Explorer" tool window: a tree of the active `.glb` / `.gltf` file's
+ * internal structure (asset, scenes, nodes, meshes, materials, accessors, images, …).
+ *
+ * - The tree is rebuilt off the EDT whenever the active editor switches to a different glTF
+ *   model, so it always mirrors the focused file.
+ * - Double-clicking a node jumps the model editor's glTF JSON to that element.
+ * - Selecting a node that maps to materials highlights them in the 3D preview.
+ */
+class GltfStructurePanel(
+    private val project: Project,
+    private val toolWindow: ToolWindow,
+) : com.intellij.openapi.ui.SimpleToolWindowPanel(true, true), Disposable {
+
+    private val treeModel = DefaultTreeModel(null)
+    private val tree = Tree(treeModel)
+
+    @Volatile
+    private var currentModelPath: String? = null
+
+    init {
+        tree.isRootVisible = true
+        tree.showsRootHandles = true
+        tree.selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
+        tree.cellRenderer = StructureCellRenderer()
+        tree.emptyText.text = "Open a .glb or .gltf file to inspect its structure"
+
+        installToolbar()
+        setContent(JBScrollPane(tree))
+
+        tree.addTreeSelectionListener { highlightSelection() }
+        object : DoubleClickListener() {
+            override fun onDoubleClick(event: MouseEvent): Boolean = navigateSelection()
+        }.installOn(tree)
+
+        project.messageBus.connect(this).subscribe(
+            FileEditorManagerListener.FILE_EDITOR_MANAGER,
+            object : FileEditorManagerListener {
+                override fun selectionChanged(event: FileEditorManagerEvent) = refreshFromSelection()
+            },
+        )
+        refreshFromSelection()
+    }
+
+    private fun installToolbar() {
+        val actions = DefaultActionGroup().apply {
+            add(object : AnAction("Refresh", "Rebuild the structure tree", AllIcons.Actions.Refresh) {
+                override fun actionPerformed(e: AnActionEvent) {
+                    currentModelPath = null
+                    refreshFromSelection()
+                }
+                override fun getActionUpdateThread() = ActionUpdateThread.EDT
+            })
+            add(object : AnAction("Expand All", null, AllIcons.Actions.Expandall) {
+                override fun actionPerformed(e: AnActionEvent) = TreeUtil.expandAll(tree)
+                override fun getActionUpdateThread() = ActionUpdateThread.EDT
+            })
+            add(object : AnAction("Collapse All", null, AllIcons.Actions.Collapseall) {
+                override fun actionPerformed(e: AnActionEvent) = TreeUtil.collapseAll(tree, 1)
+                override fun getActionUpdateThread() = ActionUpdateThread.EDT
+            })
+        }
+        val toolbar = ActionManager.getInstance().createActionToolbar("Model3DGltfStructure", actions, true)
+        toolbar.targetComponent = tree
+        setToolbar(toolbar.component)
+    }
+
+    private fun gltfModelFile(editor: FileEditor?): VirtualFile? =
+        Model3DFileSupport.resolveModelFile(editor)?.takeIf { Model3DFileSupport.isGltfStructured(it) }
+
+    private fun refreshFromSelection() {
+        val modelFile = gltfModelFile(FileEditorManager.getInstance(project).selectedEditor)
+        if (modelFile == null) {
+            currentModelPath = null
+            tree.emptyText.text = "Open a .glb or .gltf file to inspect its structure"
+            treeModel.setRoot(null)
+            return
+        }
+        if (modelFile.path == currentModelPath && treeModel.root != null) return
+
+        currentModelPath = modelFile.path
+        val path = modelFile.path
+        val name = modelFile.name
+        tree.emptyText.text = "Loading $name…"
+        treeModel.setRoot(null)
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val json = runCatching { GltfAssetParser.extractGltfJson(File(path)) }.getOrNull()
+            val root = json?.let { GltfStructureModel.build(it) }
+            ApplicationManager.getApplication().invokeLater({
+                if (project.isDisposed || currentModelPath != path) return@invokeLater
+                if (root == null) {
+                    tree.emptyText.text = "Unable to read glTF structure for $name"
+                    treeModel.setRoot(null)
+                    return@invokeLater
+                }
+                treeModel.setRoot(toTreeNode(root))
+                expandCategories()
+            }, ModalityState.any())
+        }
+    }
+
+    private fun toTreeNode(node: GltfStructureNode): DefaultMutableTreeNode {
+        val treeNode = DefaultMutableTreeNode(node)
+        node.children.forEach { treeNode.add(toTreeNode(it)) }
+        return treeNode
+    }
+
+    private fun expandCategories() {
+        val root = treeModel.root as? DefaultMutableTreeNode ?: return
+        tree.expandPath(TreePath(root.path))
+        for (i in 0 until root.childCount) {
+            tree.expandPath(TreePath((root.getChildAt(i) as DefaultMutableTreeNode).path))
+        }
+    }
+
+    private fun selectedNode(): GltfStructureNode? =
+        (tree.lastSelectedPathComponent as? DefaultMutableTreeNode)?.userObject as? GltfStructureNode
+
+    private fun highlightSelection() {
+        val file = currentModelFile() ?: return
+        val viewer = Model3DViewerService.getInstance(project).getViewerForFile(file) ?: return
+        val node = selectedNode()
+        if (node == null || node.materialIndices.isEmpty()) {
+            viewer.clearHighlight()
+        } else {
+            viewer.highlightMaterials(node.materialIndices)
+        }
+    }
+
+    private fun navigateSelection(): Boolean {
+        val node = selectedNode() ?: return false
+        val jsonPath = node.path ?: return false
+        val file = currentModelFile() ?: return false
+        val editor = FileEditorManager.getInstance(project).getEditors(file)
+            .filterIsInstance<Model3DTextEditorWithPreview>().firstOrNull() ?: return false
+
+        val document = editor.jsonTextEditor.editor.document
+        val offset = ReadAction.compute<Int?, RuntimeException> {
+            val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document) as? JsonFile
+                ?: return@compute null
+            GltfJsonPathLocator.offsetForPath(psiFile, jsonPath)
+        } ?: return false
+
+        FileEditorManager.getInstance(project).openFile(file, true)
+        editor.revealJsonLocation(offset)
+        return true
+    }
+
+    private fun currentModelFile(): VirtualFile? =
+        gltfModelFile(FileEditorManager.getInstance(project).selectedEditor)
+
+    override fun dispose() {}
+
+    private class StructureCellRenderer : ColoredTreeCellRenderer() {
+        override fun customizeCellRenderer(
+            tree: JTree,
+            value: Any?,
+            selected: Boolean,
+            expanded: Boolean,
+            leaf: Boolean,
+            row: Int,
+            hasFocus: Boolean,
+        ) {
+            val node = (value as? DefaultMutableTreeNode)?.userObject as? GltfStructureNode ?: return
+            append(node.label)
+            node.secondary?.let { append("  $it", SimpleTextAttributes.GRAYED_ATTRIBUTES) }
+        }
+    }
+}

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureToolWindow.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureToolWindow.kt
@@ -1,0 +1,41 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.wm.ToolWindowManager
+
+/**
+ * Shared logic for showing/hiding the "Model Explorer" tool window stripe. Toggling
+ * availability only inspects the focused file's extension (no disk IO), so it is safe on the
+ * EDT and during editor restore.
+ */
+object GltfStructureToolWindow {
+
+    fun updateAvailability(project: Project) {
+        if (project.isDisposed) return
+        val toolWindow = ToolWindowManager.getInstance(project)
+            .getToolWindow(GltfStructureToolWindowFactory.ID) ?: return
+        val modelFile = Model3DFileSupport.resolveModelFile(
+            FileEditorManager.getInstance(project).selectedEditor,
+        )
+        toolWindow.isAvailable = Model3DFileSupport.isGltfStructured(modelFile)
+    }
+}
+
+/**
+ * Sets the initial stripe visibility once the project has opened, so a `.glb` / `.gltf`
+ * restored as the active tab shows the tool window without waiting for the next selection
+ * change (the availability listener may run before the tool window is registered).
+ */
+class GltfStructureStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        ApplicationManager.getApplication().invokeLater(
+            { GltfStructureToolWindow.updateAvailability(project) },
+            ModalityState.any(),
+        )
+    }
+}
+

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureToolWindowFactory.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureToolWindowFactory.kt
@@ -1,0 +1,29 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.content.ContentFactory
+
+/**
+ * Registers the "Model Explorer" tool window, which shows the internal structure of the
+ * active `.glb` / `.gltf` file. The stripe button is hidden by default (see
+ * [shouldBeAvailable]) and toggled on by [GltfStructureAvailabilityListener] only while a
+ * glTF model is in focus, so it never clutters non-3D projects.
+ */
+class GltfStructureToolWindowFactory : ToolWindowFactory, DumbAware {
+
+    override fun shouldBeAvailable(project: Project): Boolean = false
+
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = GltfStructurePanel(project, toolWindow)
+        val content = ContentFactory.getInstance().createContent(panel, "", false)
+        content.setDisposer(panel)
+        toolWindow.contentManager.addContent(content)
+    }
+
+    companion object {
+        const val ID: String = "Model Explorer"
+    }
+}

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureToolWindowFactory.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructureToolWindowFactory.kt
@@ -17,7 +17,7 @@ class GltfStructureToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun shouldBeAvailable(project: Project): Boolean = false
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        val panel = GltfStructurePanel(project, toolWindow)
+        val panel = GltfStructurePanel(project)
         val content = ContentFactory.getInstance().createContent(panel, "", false)
         content.setDisposer(panel)
         toolWindow.contentManager.addContent(content)

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DFileSupport.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DFileSupport.kt
@@ -12,6 +12,14 @@ import com.intellij.openapi.vfs.VirtualFile
  */
 object Model3DFileSupport {
     private val BUILT_IN_EXTENSIONS = setOf("glb", "gltf", "stl")
+    private val GLTF_EXTENSIONS = setOf("glb", "gltf")
+
+    /**
+     * True for glTF-family files (`.glb` / `.gltf`) whose JSON structure the glTF Structure
+     * tool window can inspect. STL/OBJ/three.js JSON have no glTF asset/accessor/material graph.
+     */
+    fun isGltfStructured(file: VirtualFile?): Boolean =
+        file?.extension?.lowercase() in GLTF_EXTENSIONS
 
     fun isSupported(file: VirtualFile?): Boolean {
         val extension = file?.extension?.lowercase() ?: return false

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
@@ -3,6 +3,7 @@ package ke.co.coterie.plugins.model3dviewer
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.editor.ScrollType
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileEditor.TextEditorWithPreview
@@ -41,6 +42,25 @@ class Model3DTextEditorWithPreview(
      */
     val modelFile: VirtualFile?
         get() = previewEditor.file
+
+    /** The glTF JSON side of this editor, exposed for structure-tree navigation. */
+    val jsonTextEditor: TextEditor = textEditor
+
+    /**
+     * Reveals [offset] in the glTF JSON side: makes the editor visible (if only the preview
+     * was showing) and moves the caret there. Used by the glTF Structure tool window to jump
+     * to the JSON of a selected structure node.
+     */
+    fun revealJsonLocation(offset: Int) {
+        if (getLayout() == Layout.SHOW_PREVIEW) {
+            setLayout(Layout.SHOW_EDITOR_AND_PREVIEW)
+        }
+        val ed = jsonTextEditor.editor
+        if (offset in 0..ed.document.textLength) {
+            ed.caretModel.moveToOffset(offset)
+            ed.scrollingModel.scrollToCaret(ScrollType.CENTER)
+        }
+    }
 
     companion object {
         private val JSON_EXTENSIONS = setOf("gltf", "glb")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,7 @@
     <li>Auto-rotate toggle via status bar</li>
     <li>Animation playback controls (play/pause)</li>
     <li>Animation selector for models with multiple animations</li>
+    <li>Model Explorer tool window: browse the internal structure (materials, meshes, accessors, images, &hellip;) of GLB/GLTF files, with click-to-navigate the glTF JSON and material highlighting in the preview</li>
 </ul>
 
 <h2>Supported File Formats</h2>
@@ -137,11 +138,24 @@
 
         <!-- Startup activity to initialize OBJ file type registration -->
         <postStartupActivity implementation="ke.co.coterie.plugins.model3dviewer.ObjFileTypeStartupActivity"/>
+        <!-- Sets initial glTF Structure tool window visibility for a restored glTF/GLB tab -->
+        <postStartupActivity implementation="ke.co.coterie.plugins.model3dviewer.GltfStructureStartupActivity"/>
+
+        <!-- Tool window revealing the internal structure of the active glTF/GLB file.
+             Hidden by default; shown only while a .glb/.gltf file is in focus. -->
+        <toolWindow id="Model Explorer"
+                    anchor="right"
+                    secondary="true"
+                    icon="AllIcons.Toolwindows.ToolWindowStructure"
+                    factoryClass="ke.co.coterie.plugins.model3dviewer.GltfStructureToolWindowFactory"/>
     </extensions>
 
     <projectListeners>
         <!-- Shows a one-time Got It tooltip when a three.js model JSON is first opened. -->
         <listener class="ke.co.coterie.plugins.model3dviewer.Model3DJsonGotItListener"
+                  topic="com.intellij.openapi.fileEditor.FileEditorManagerListener"/>
+        <!-- Toggles the glTF Structure tool window stripe based on the focused file. -->
+        <listener class="ke.co.coterie.plugins.model3dviewer.GltfStructureAvailabilityListener"
                   topic="com.intellij.openapi.fileEditor.FileEditorManagerListener"/>
     </projectListeners>
 </idea-plugin>


### PR DESCRIPTION
Adds a **Model Explorer** tool window that reveals the internal structure of the active `.glb` / `.gltf` file.

Closes #48.

## What it does
- Tree of the model's glTF structure: **Asset, Scenes, Nodes, Meshes, Materials, Accessors, Buffer Views, Buffers, Textures, Images, Samplers, Animations, Skins, Cameras, Extensions** — each with counts and per-item summaries (e.g. `Accessor 3 — VEC3/FLOAT ×24`, `Material 0 — OPAQUE`).
- **Double-click a node** -> navigates the glTF JSON editor to that element.
- **Select a material / mesh / node** -> highlights the corresponding materials in the 3D preview.
- Toolbar: Refresh, Expand All, Collapse All.

## Scope & UX
- glTF-family only (`.glb` / `.gltf`); STL/OBJ/three.js JSON have no asset/accessor/material graph.
- Vertical tool window on the right; the stripe is **hidden unless a glTF/GLB file is in focus** (availability listener + a startup activity for restored tabs). Availability toggling only checks the file extension — no disk IO on the EDT.

## Design notes
- The tree is built **off the EDT** from `GltfAssetParser.extractGltfJson` + `GltfMaterialIndex` (both already in the plugin), and rebuilt when the active editor switches to a different glTF model.
- Navigation uses a **structural JSON-path resolver** (`GltfJsonPathLocator`) against the editor's JSON PSI, so offsets stay correct against the pretty-printed JSON even though the tree was parsed from the raw JSON.
- Highlighting reuses the existing `Model3DViewer.highlightMaterials` / `clearHighlight` bridge.
- New files: `GltfStructureModel`, `GltfStructurePanel`, `GltfStructureToolWindowFactory`, `GltfStructureAvailabilityListener`, `GltfStructureToolWindow` (+ startup activity), `GltfJsonPathLocator`. Plus `Model3DFileSupport.isGltfStructured` and a `revealJsonLocation` helper on the split editor.

## Verification
`compileKotlin` clean; sandbox verified: tree renders for glb/gltf, double-click navigation and material highlighting work, stripe auto-hides on non-glTF tabs. No slow-op/NPE in the log.