### PR TITLE
fix(editor): avoid Structure view disposing a throwaway 3D editor

### DIFF
--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DEditorProvider.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DEditorProvider.kt
@@ -1,14 +1,16 @@
 package ke.co.coterie.plugins.model3dviewer
 
+import com.intellij.ide.structureView.StructureViewBuilder
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorPolicy
 import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.fileEditor.ex.StructureViewFileEditorProvider
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import org.jetbrains.annotations.NonNls
 
-class Model3DEditorProvider : FileEditorProvider, DumbAware {
+class Model3DEditorProvider : FileEditorProvider, DumbAware, StructureViewFileEditorProvider {
 
     override fun accept(
         project: Project,
@@ -31,6 +33,16 @@ class Model3DEditorProvider : FileEditorProvider, DumbAware {
             preview
         }
     }
+
+    /**
+     * Implemented so the Structure tool window resolves a builder *without* creating and
+     * immediately disposing a throwaway [Model3DTextEditorWithPreview] (see
+     * [StructureViewFileEditorProvider] javadoc). That throwaway path raced our composite
+     * editor's deferred UI initialization against its disposal, throwing
+     * IncorrectOperationException. We expose no structural view for 3D model files (the
+     * Model Explorer tool window covers glTF/GLB), so return null.
+     */
+    override fun getStructureViewBuilder(project: Project, file: VirtualFile): StructureViewBuilder? = null
 
     override fun getEditorTypeId(): @NonNls String {
         return "MODEL_3D_EDITOR"

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DJsonEditorProvider.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DJsonEditorProvider.kt
@@ -1,10 +1,12 @@
 package ke.co.coterie.plugins.model3dviewer
 
+import com.intellij.ide.structureView.StructureViewBuilder
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorPolicy
 import com.intellij.openapi.fileEditor.FileEditorProvider
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileEditor.TextEditorWithPreview
+import com.intellij.openapi.fileEditor.ex.StructureViewFileEditorProvider
 import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -24,7 +26,7 @@ import org.jetbrains.annotations.NonNls
  * editor/preview toggle and avoids the platform's multi-provider selection edge
  * cases.
  */
-class Model3DJsonEditorProvider : FileEditorProvider, DumbAware {
+class Model3DJsonEditorProvider : FileEditorProvider, DumbAware, StructureViewFileEditorProvider {
 
     override fun accept(project: Project, file: VirtualFile): Boolean =
         Model3DJsonSupport.isThreeJsModelJson(file)
@@ -42,6 +44,15 @@ class Model3DJsonEditorProvider : FileEditorProvider, DumbAware {
             preview
         }
     }
+
+    /**
+     * Implemented so the Structure tool window never spins up and immediately disposes a
+     * throwaway [Model3DTextEditorWithPreview] just to read its structure builder (see
+     * [StructureViewFileEditorProvider] javadoc); that race threw
+     * IncorrectOperationException. When this model JSON is the active editor the live
+     * composite still exposes the normal JSON structure, so returning null here is safe.
+     */
+    override fun getStructureViewBuilder(project: Project, file: VirtualFile): StructureViewBuilder? = null
 
     override fun getEditorTypeId(): @NonNls String = EDITOR_TYPE_ID
 


### PR DESCRIPTION
## Problem

Opening the built-in **Structure** tool window (Alt+7) while a `.glb`/`.gltf` (or three.js model `.json`) file was involved could throw:

```
com.intellij.util.IncorrectOperationException: ... has already been disposed ... will never be disposed
    at com.intellij.openapi.editor.toolbar.floating.TransparentComponentAnimator.<init>
    at com.intellij.openapi.fileEditor.TextEditorWithPreview$TextEditorWithPreviewUi.<init>
    at com.intellij.ide.impl.StructureViewWrapperImpl$createStructureViewBuilder$4.invokeSuspend
```

### Root cause

When the Structure tool window needs a file's structure and that file is **not** the active editor, the platform (`StructureViewWrapperImpl.createStructureViewBuilder`) creates a **temporary** `FileEditor`, reads its `structureViewBuilder`, and disposes it in a `finally`. Our `Model3DTextEditorWithPreview` (a `TextEditorWithPreview`) defers its UI initialization via `invokeLater` in its constructor, so that init ran **after** the immediate disposal and tried to register a child disposable (the floating-toolbar animator) under an already-disposed parent — hence the exception. This is pre-existing and independent of the Model Explorer feature.

## Fix

Both `Model3DEditorProvider` and `Model3DJsonEditorProvider` now implement `com.intellij.openapi.fileEditor.ex.StructureViewFileEditorProvider` and return `null` from `getStructureViewBuilder`. Per that interface's own javadoc, implementing it is *"used instead of creating a temp FileEditor just to call `FileEditor#getStructureViewBuilder()`"* — so the throwaway editor is never created and the disposal race disappears.

When a model file **is** the active editor, its structure still comes from the live editor's builder, so that path is unaffected. glTF/GLB structure is now surfaced by the dedicated **Model Explorer** tool window.

## Testing

- `./gradlew compileKotlin` — clean.
- Sandbox IDE startup log clean (no `IncorrectOperationException`); verified opening the Structure tool window on an active glb/gltf no longer throws.
