### PR TITLE
fix(model-explorer): guard structure refresh against stale overlapping parses

### DIFF
--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
@@ -51,6 +51,10 @@ class GltfStructurePanel(
     @Volatile
     private var currentModelPath: String? = null
 
+    // Incremented on the EDT for every scheduled rebuild so a slower, earlier parse
+    // can't overwrite the tree produced by a later one (e.g. Refresh clicked twice).
+    private var refreshGeneration = 0
+
     init {
         tree.isRootVisible = true
         tree.showsRootHandles = true
@@ -114,6 +118,7 @@ class GltfStructurePanel(
         currentModelPath = modelFile.path
         val path = modelFile.path
         val name = modelFile.name
+        val generation = ++refreshGeneration
         tree.emptyText.text = "Loading $name…"
         treeModel.setRoot(null)
 
@@ -121,7 +126,7 @@ class GltfStructurePanel(
             val json = runCatching { GltfAssetParser.extractGltfJson(File(path)) }.getOrNull()
             val root = json?.let { GltfStructureModel.build(it) }
             ApplicationManager.getApplication().invokeLater({
-                if (project.isDisposed || currentModelPath != path) return@invokeLater
+                if (project.isDisposed || generation != refreshGeneration || currentModelPath != path) return@invokeLater
                 if (root == null) {
                     tree.emptyText.text = "Unable to read glTF structure for $name"
                     treeModel.setRoot(null)


### PR DESCRIPTION
Addresses a follow-up review comment on #49 (Model Explorer).

## Problem

`GltfStructurePanel.refreshFromSelection()` rebuilds the structure tree on a pooled thread and, in the `invokeLater` callback, only guarded the result with `currentModelPath != path`. Two refreshes for the **same** file can overlap — e.g. clicking **Refresh** twice (which resets `currentModelPath = null` and reschedules), or a selection-triggered refresh firing while a previous parse is still running. Both tasks then pass the `path` check, so whichever finishes **last** wins. A slower, earlier parse can overwrite the tree produced by a later one, which is stale if the file changed on disk between the two reads.

## Fix

Add a per-refresh `refreshGeneration` token, incremented on the EDT for every scheduled rebuild and captured before dispatching the pooled parse. The `invokeLater` callback now applies results only if its captured generation still matches the latest, so only the most recently scheduled rebuild updates the tree. (`refreshFromSelection` runs on the EDT for all call sites — init, selection changes, and the Refresh action — so the counter needs no extra synchronization.)

## Testing

- `./gradlew compileKotlin` — clean.
