### PR TITLE
fix(status-bar): hide animation widgets for models without animations

### DIFF
--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationSelectorWidget.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationSelectorWidget.kt
@@ -1,5 +1,6 @@
 package ke.co.coterie.plugins.model3dviewer
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.vfs.VirtualFile
@@ -88,6 +89,13 @@ class Model3DAnimationSelectorWidget(project: Project) : EditorBasedWidget(proje
     }
 
     private fun updateUIForState(state: Model3DAnimationStateService.FileAnimationState) {
+        // Animation discovery arrives via the JCEF JS bridge, which invokes the
+        // state-change listener off the EDT; marshal Swing mutations back onto it.
+        val app = ApplicationManager.getApplication()
+        if (!app.isDispatchThread) {
+            app.invokeLater { updateUIForState(state) }
+            return
+        }
         isUpdating = true
         try {
             comboBoxModel.removeAllElements()

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationSelectorWidget.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationSelectorWidget.kt
@@ -93,7 +93,9 @@ class Model3DAnimationSelectorWidget(project: Project) : EditorBasedWidget(proje
         // state-change listener off the EDT; marshal Swing mutations back onto it.
         val app = ApplicationManager.getApplication()
         if (!app.isDispatchThread) {
-            app.invokeLater { updateUIForState(state) }
+            app.invokeLater {
+                if (!project.isDisposed) updateUIForState(state)
+            }
             return
         }
         isUpdating = true

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationSelectorWidget.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationSelectorWidget.kt
@@ -45,7 +45,7 @@ class Model3DAnimationSelectorWidget(project: Project) : EditorBasedWidget(proje
         }
     }
 
-    private val label = JBLabel("Pick animation:").apply {
+    private val label = JBLabel("Animation:").apply {
         isEnabled = false // Disabled by default until animations are available
     }
 
@@ -64,17 +64,17 @@ class Model3DAnimationSelectorWidget(project: Project) : EditorBasedWidget(proje
     }
 
     private val viewerChangeListener: (VirtualFile?, Model3DViewer?) -> Unit = { file, viewer ->
-        // Only show this widget while a supported 3D model file is in focus
-        setWidgetVisible(file != null)
         if (file != null) {
             val state = animationStateService.getState(file)
+            // Visibility (handled in updateUIForState) follows whether the model
+            // is animated, so the selector is hidden for models without animations.
             updateUIForState(state)
             // Sync selected animation with the newly selected viewer
             state.selectedAnimation?.let { animation ->
                 viewer?.selectAnimation(animation)
             }
         } else {
-            // No 3D model file selected, reset UI
+            // No 3D model file selected, hide the widget
             updateUIForState(Model3DAnimationStateService.FileAnimationState())
         }
     }
@@ -93,6 +93,8 @@ class Model3DAnimationSelectorWidget(project: Project) : EditorBasedWidget(proje
             comboBoxModel.removeAllElements()
             state.availableAnimations.forEach { comboBoxModel.addElement(it) }
             val hasAnimations = state.availableAnimations.isNotEmpty()
+            // Only show the selector when the model actually has animations.
+            setWidgetVisible(hasAnimations)
             comboBox.isEnabled = hasAnimations
             label.isEnabled = hasAnimations
             if (hasAnimations && state.selectedAnimation != null) {
@@ -109,12 +111,12 @@ class Model3DAnimationSelectorWidget(project: Project) : EditorBasedWidget(proje
         animationStateService.addStateChangeListener(animationStateListener)
         viewerService.addViewerChangeListener(viewerChangeListener)
 
-        setWidgetVisible(Model3DFileSupport.isSupportedFileInFocus(project))
-
-        // Initialize with current file's state if available
-        viewerService.getCurrentFile()?.let { file ->
-            val state = animationStateService.getState(file)
-            updateUIForState(state)
+        // The widget stays hidden unless the focused model has animations.
+        val currentFile = viewerService.getCurrentFile()
+        if (currentFile != null) {
+            updateUIForState(animationStateService.getState(currentFile))
+        } else {
+            setWidgetVisible(false)
         }
     }
 

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationSelectorWidget.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationSelectorWidget.kt
@@ -60,7 +60,7 @@ class Model3DAnimationSelectorWidget(project: Project) : EditorBasedWidget(proje
     private val animationStateListener: (VirtualFile, Model3DAnimationStateService.FileAnimationState) -> Unit = { file, state ->
         // Only update if this is the currently active file
         if (viewerService.getCurrentFile()?.path == file.path) {
-            updateUIForState(state)
+            updateUIForState(state, file)
         }
     }
 
@@ -69,14 +69,14 @@ class Model3DAnimationSelectorWidget(project: Project) : EditorBasedWidget(proje
             val state = animationStateService.getState(file)
             // Visibility (handled in updateUIForState) follows whether the model
             // is animated, so the selector is hidden for models without animations.
-            updateUIForState(state)
+            updateUIForState(state, file)
             // Sync selected animation with the newly selected viewer
             state.selectedAnimation?.let { animation ->
                 viewer?.selectAnimation(animation)
             }
         } else {
             // No 3D model file selected, hide the widget
-            updateUIForState(Model3DAnimationStateService.FileAnimationState())
+            updateUIForState(Model3DAnimationStateService.FileAnimationState(), null)
         }
     }
 
@@ -88,16 +88,19 @@ class Model3DAnimationSelectorWidget(project: Project) : EditorBasedWidget(proje
         }
     }
 
-    private fun updateUIForState(state: Model3DAnimationStateService.FileAnimationState) {
+    private fun updateUIForState(state: Model3DAnimationStateService.FileAnimationState, file: VirtualFile?) {
         // Animation discovery arrives via the JCEF JS bridge, which invokes the
         // state-change listener off the EDT; marshal Swing mutations back onto it.
         val app = ApplicationManager.getApplication()
         if (!app.isDispatchThread) {
             app.invokeLater {
-                if (!project.isDisposed) updateUIForState(state)
+                if (!project.isDisposed) updateUIForState(state, file)
             }
             return
         }
+        // Focus may have moved to another file between an off-EDT discovery and
+        // this deferred apply; ignore a state that no longer matches the focus.
+        if (file != null && viewerService.getCurrentFile()?.path != file.path) return
         isUpdating = true
         try {
             comboBoxModel.removeAllElements()
@@ -124,7 +127,7 @@ class Model3DAnimationSelectorWidget(project: Project) : EditorBasedWidget(proje
         // The widget stays hidden unless the focused model has animations.
         val currentFile = viewerService.getCurrentFile()
         if (currentFile != null) {
-            updateUIForState(animationStateService.getState(currentFile))
+            updateUIForState(animationStateService.getState(currentFile), currentFile)
         } else {
             setWidgetVisible(false)
         }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationWidget.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationWidget.kt
@@ -33,7 +33,7 @@ class Model3DAnimationWidget(project: Project) : EditorBasedWidget(project), Cus
     private val animationStateListener: (VirtualFile, Model3DAnimationStateService.FileAnimationState) -> Unit = { file, state ->
         // Only update if this is the currently active file
         if (viewerService.getCurrentFile()?.path == file.path) {
-            updateUIForState(state)
+            updateUIForState(state, file)
         }
     }
 
@@ -42,12 +42,12 @@ class Model3DAnimationWidget(project: Project) : EditorBasedWidget(project), Cus
             val state = animationStateService.getState(file)
             // Visibility (handled in updateUIForState) follows whether the model
             // is animated, so the toggle is hidden for models without animations.
-            updateUIForState(state)
+            updateUIForState(state, file)
             // Sync animation playing state with the newly selected viewer
             viewer?.toggleAnimation(state.isPlaying)
         } else {
             // No 3D model file selected, hide the widget
-            updateUIForState(Model3DAnimationStateService.FileAnimationState())
+            updateUIForState(Model3DAnimationStateService.FileAnimationState(), null)
         }
     }
 
@@ -59,16 +59,19 @@ class Model3DAnimationWidget(project: Project) : EditorBasedWidget(project), Cus
         }
     }
 
-    private fun updateUIForState(state: Model3DAnimationStateService.FileAnimationState) {
+    private fun updateUIForState(state: Model3DAnimationStateService.FileAnimationState, file: VirtualFile?) {
         // Animation discovery arrives via the JCEF JS bridge, which invokes the
         // state-change listener off the EDT; marshal Swing mutations back onto it.
         val app = ApplicationManager.getApplication()
         if (!app.isDispatchThread) {
             app.invokeLater {
-                if (!project.isDisposed) updateUIForState(state)
+                if (!project.isDisposed) updateUIForState(state, file)
             }
             return
         }
+        // Focus may have moved to another file between an off-EDT discovery and
+        // this deferred apply; ignore a state that no longer matches the focus.
+        if (file != null && viewerService.getCurrentFile()?.path != file.path) return
         val hasAnimations = state.availableAnimations.isNotEmpty()
         // Only show the toggle when the model actually has animations.
         setWidgetVisible(hasAnimations)
@@ -83,7 +86,7 @@ class Model3DAnimationWidget(project: Project) : EditorBasedWidget(project), Cus
         // The widget stays hidden unless the focused model has animations.
         val currentFile = viewerService.getCurrentFile()
         if (currentFile != null) {
-            updateUIForState(animationStateService.getState(currentFile))
+            updateUIForState(animationStateService.getState(currentFile), currentFile)
         } else {
             setWidgetVisible(false)
         }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationWidget.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationWidget.kt
@@ -1,5 +1,6 @@
 package ke.co.coterie.plugins.model3dviewer
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.CustomStatusBarWidget
@@ -59,6 +60,13 @@ class Model3DAnimationWidget(project: Project) : EditorBasedWidget(project), Cus
     }
 
     private fun updateUIForState(state: Model3DAnimationStateService.FileAnimationState) {
+        // Animation discovery arrives via the JCEF JS bridge, which invokes the
+        // state-change listener off the EDT; marshal Swing mutations back onto it.
+        val app = ApplicationManager.getApplication()
+        if (!app.isDispatchThread) {
+            app.invokeLater { updateUIForState(state) }
+            return
+        }
         val hasAnimations = state.availableAnimations.isNotEmpty()
         // Only show the toggle when the model actually has animations.
         setWidgetVisible(hasAnimations)

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationWidget.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationWidget.kt
@@ -37,15 +37,15 @@ class Model3DAnimationWidget(project: Project) : EditorBasedWidget(project), Cus
     }
 
     private val viewerChangeListener: (VirtualFile?, Model3DViewer?) -> Unit = { file, viewer ->
-        // Only show this widget while a supported 3D model file is in focus
-        setWidgetVisible(file != null)
         if (file != null) {
             val state = animationStateService.getState(file)
+            // Visibility (handled in updateUIForState) follows whether the model
+            // is animated, so the toggle is hidden for models without animations.
             updateUIForState(state)
             // Sync animation playing state with the newly selected viewer
             viewer?.toggleAnimation(state.isPlaying)
         } else {
-            // No 3D model file selected, reset UI
+            // No 3D model file selected, hide the widget
             updateUIForState(Model3DAnimationStateService.FileAnimationState())
         }
     }
@@ -60,6 +60,8 @@ class Model3DAnimationWidget(project: Project) : EditorBasedWidget(project), Cus
 
     private fun updateUIForState(state: Model3DAnimationStateService.FileAnimationState) {
         val hasAnimations = state.availableAnimations.isNotEmpty()
+        // Only show the toggle when the model actually has animations.
+        setWidgetVisible(hasAnimations)
         checkbox.isEnabled = hasAnimations
         checkbox.isSelected = if (hasAnimations) state.isPlaying else false
     }
@@ -68,12 +70,12 @@ class Model3DAnimationWidget(project: Project) : EditorBasedWidget(project), Cus
         animationStateService.addStateChangeListener(animationStateListener)
         viewerService.addViewerChangeListener(viewerChangeListener)
 
-        setWidgetVisible(Model3DFileSupport.isSupportedFileInFocus(project))
-
-        // Initialize with current file's state if available
-        viewerService.getCurrentFile()?.let { file ->
-            val state = animationStateService.getState(file)
-            updateUIForState(state)
+        // The widget stays hidden unless the focused model has animations.
+        val currentFile = viewerService.getCurrentFile()
+        if (currentFile != null) {
+            updateUIForState(animationStateService.getState(currentFile))
+        } else {
+            setWidgetVisible(false)
         }
     }
 

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationWidget.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DAnimationWidget.kt
@@ -64,7 +64,9 @@ class Model3DAnimationWidget(project: Project) : EditorBasedWidget(project), Cus
         // state-change listener off the EDT; marshal Swing mutations back onto it.
         val app = ApplicationManager.getApplication()
         if (!app.isDispatchThread) {
-            app.invokeLater { updateUIForState(state) }
+            app.invokeLater {
+                if (!project.isDisposed) updateUIForState(state)
+            }
             return
         }
         val hasAnimations = state.availableAnimations.isNotEmpty()


### PR DESCRIPTION
## What
The **Toggle animation** checkbox and the **Animation** selector in the status bar previously stayed visible (just greyed out) for any focused 3D model, including ones with no animations. They now disappear entirely for static models and reappear once animations are discovered.

Also renames the selector label from `Pick animation:` to `Animation:`.

## How
Both widgets already tracked `hasAnimations` per file to toggle *enabled* state; that same signal now also drives component visibility via `setWidgetVisible(...)` inside `updateUIForState`. Visibility updates on:
- viewer/file change (`viewerChangeListener`),
- async animation discovery (`animationStateListener`, since animations load after the model),
- widget init.

Removed the old `setWidgetVisible(isSupportedFileInFocus)` gating so a supported-but-static model no longer shows the controls.

## Testing
Verified in the sandbox IDE: animated `.glb` shows both controls; static models show neither; switching between them updates correctly; no errors on startup.