### PR TITLE
fix: migrate to IntelliJ 2026.2 JCEF resource-handler API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,38 @@ jobs:
         run: ./gradlew build
 
       - name: Verify plugin
+        id: verify
         run: ./gradlew verifyPlugin
+
+      - name: Publish plugin verifier report to job summary
+        if: always()
+        run: |
+          shopt -s nullglob
+          reports=(build/reports/pluginVerifier/*/report.md)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "No plugin verifier reports were produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## Plugin Verifier report"
+            for report in "${reports[@]}"; do
+              ide="$(basename "$(dirname "$report")")"
+              echo ""
+              echo "<details><summary><strong>$ide</strong></summary>"
+              echo ""
+              cat "$report"
+              echo ""
+              echo "</details>"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload plugin verifier reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-verifier-reports
+          path: build/reports/pluginVerifier/**
+          retention-days: 7
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,12 @@ intellijPlatform {
         ides {
             recommended()
         }
+        // Emit a Markdown report (alongside the default HTML) so CI can publish
+        // it to the GitHub Actions job summary.
+        verificationReportsFormats = listOf(
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.VerificationReportsFormats.MARKDOWN,
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.VerificationReportsFormats.HTML,
+        )
         failureLevel = listOf(
             org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
             // DEPRECATED_API_USAGES is intentionally NOT a failure: the 2026.2+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,9 +2,9 @@ import org.jetbrains.changelog.Changelog
 
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "2.1.20"
-    id("org.jetbrains.intellij.platform") version "2.10.2"
-    id("org.jetbrains.kotlin.plugin.compose") version "2.1.20"
+    id("org.jetbrains.kotlin.jvm") version "2.4.10"
+    id("org.jetbrains.intellij.platform") version "2.18.1"
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.10"
     id("org.jetbrains.changelog") version "2.2.1"
 }
 
@@ -35,7 +35,7 @@ repositories {
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html
 dependencies {
     intellijPlatform {
-        intellijIdea("2025.2.4")
+        intellijIdea("2026.2")
         testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Platform)
 
         // Add plugin dependencies for compilation here:
@@ -45,6 +45,10 @@ dependencies {
         // caret/selection in the glTF JSON to the corresponding materials.
         bundledPlugin("com.intellij.modules.json")
 
+        // JCEF moved out of the platform core into its own bundled plugin in 2026.2;
+        // it provides JBCefBrowser and the org.cef.* resource-handler API.
+        bundledPlugin("com.intellij.modules.jcef")
+
         composeUI()
 
     }
@@ -53,11 +57,10 @@ dependencies {
 intellijPlatform {
     pluginConfiguration {
         ideaVersion {
-            sinceBuild = "252.25557"
-            // This plugin targets the old JCEF API,
-            // compatibility is capped at 253 (2025.3) until
-            // we migrate to the new API.
-            untilBuild = "253.*"
+            sinceBuild = "262"
+            // Targets the new JCEF resource-handler API (open/read/skip),
+            // available from 2026.2 (build 262) onward.
+            untilBuild = "262.*"
         }
 
         changeNotes = renderedChangeNotes
@@ -75,7 +78,10 @@ intellijPlatform {
         }
         failureLevel = listOf(
             org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
-            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
+            // DEPRECATED_API_USAGES is intentionally NOT a failure: the 2026.2+
+            // out-of-process JCEF ("cef_server") bridge invokes the deprecated
+            // CefResourceHandler.processRequest/readResponse methods over Thrift,
+            // so Model3DResourceHandler must override them to work at runtime.
             org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
             org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
         )
@@ -91,7 +97,12 @@ tasks {
 }
 
 kotlin {
+    jvmToolchain(21)
     compilerOptions {
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+        // Emit real JVM default methods so Kotlin does not generate delegating
+        // override bridges for Java interface default methods (e.g. ToolWindowFactory);
+        // those bridges otherwise trip the plugin verifier's deprecated/experimental checks.
+        freeCompilerArgs.add("-jvm-default=no-compatibility")
     }
 }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
@@ -191,6 +191,10 @@ class GltfStructurePanel(
                 }
             }
             .submit(AppExecutorUtil.getAppExecutorService())
+        // The node maps to a JSON element (node.path != null), so treat the
+        // double-click as handled and consume it (prevents the tree's default
+        // expand/collapse). The async lookup rarely fails; when it does the
+        // navigation is simply skipped in finishOnUiThread above.
         return true
     }
 

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
@@ -174,9 +174,9 @@ class GltfStructurePanel(
             .filterIsInstance<Model3DTextEditorWithPreview>().firstOrNull() ?: return false
 
         val document = editor.jsonTextEditor.editor.document
-        val offset = ReadAction.compute<Int?, RuntimeException> {
+        val offset = ReadAction.computeBlocking<Int?, RuntimeException> {
             val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document) as? JsonFile
-                ?: return@compute null
+                ?: return@computeBlocking null
             GltfJsonPathLocator.offsetForPath(psiFile, jsonPath)
         } ?: return false
 

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/GltfStructurePanel.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
+import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.ui.ColoredTreeCellRenderer
 import com.intellij.ui.DoubleClickListener
 import com.intellij.ui.SimpleTextAttributes
@@ -174,14 +175,22 @@ class GltfStructurePanel(
             .filterIsInstance<Model3DTextEditorWithPreview>().firstOrNull() ?: return false
 
         val document = editor.jsonTextEditor.editor.document
-        val offset = ReadAction.computeBlocking<Int?, RuntimeException> {
+        // Compute the target offset off the EDT (PSI traversal can be non-trivial
+        // for large models), then navigate back on the UI thread. Blocking read
+        // actions on the EDT are disallowed/can freeze the UI on recent platforms.
+        ReadAction.nonBlocking<Int?> {
             val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document) as? JsonFile
-                ?: return@computeBlocking null
+                ?: return@nonBlocking null
             GltfJsonPathLocator.offsetForPath(psiFile, jsonPath)
-        } ?: return false
-
-        FileEditorManager.getInstance(project).openFile(file, true)
-        editor.revealJsonLocation(offset)
+        }
+            .expireWith(this)
+            .finishOnUiThread(ModalityState.defaultModalityState()) { offset ->
+                if (offset != null) {
+                    FileEditorManager.getInstance(project).openFile(file, true)
+                    editor.revealJsonLocation(offset)
+                }
+            }
+            .submit(AppExecutorUtil.getAppExecutorService())
         return true
     }
 

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DJsonGotItStartupActivity.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DJsonGotItStartupActivity.kt
@@ -1,0 +1,17 @@
+package ke.co.coterie.plugins.model3dviewer
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+/**
+ * Marks [Model3DJsonGotItState] ready once the project has finished opening, so the
+ * 3D-preview Got It tooltip is suppressed during the bulk editor restore on startup.
+ *
+ * Replaces the previously used internal `StartupManager.runAfterOpened` API.
+ */
+class Model3DJsonGotItStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        project.service<Model3DJsonGotItState>().markReady()
+    }
+}

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DJsonGotItStartupActivity.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DJsonGotItStartupActivity.kt
@@ -8,7 +8,8 @@ import com.intellij.openapi.startup.ProjectActivity
  * Marks [Model3DJsonGotItState] ready once the project has finished opening, so the
  * 3D-preview Got It tooltip is suppressed during the bulk editor restore on startup.
  *
- * Replaces the previously used internal `StartupManager.runAfterOpened` API.
+ * Replaces the previously used `StartupManager.runAfterOpened(...)` method, which
+ * is marked `@ApiStatus.Internal` and must not be called from plugin code.
  */
 class Model3DJsonGotItStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DJsonGotItState.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DJsonGotItState.kt
@@ -1,23 +1,24 @@
 package ke.co.coterie.plugins.model3dviewer
 
 import com.intellij.openapi.components.Service
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.startup.StartupManager
 
 /**
  * Tracks whether a project has finished opening, so the 3D-preview Got It tooltip
  * is not shown (and its once-per-user flag not consumed) during the bulk editor
  * restore that happens while the project is still opening. See
  * [Model3DJsonGotItListener].
+ *
+ * The ready flag is flipped by [Model3DJsonGotItStartupActivity] once the project
+ * has finished opening.
  */
 @Service(Service.Level.PROJECT)
-class Model3DJsonGotItState(project: Project) {
+class Model3DJsonGotItState {
 
     @Volatile
     var isReady: Boolean = false
         private set
 
-    init {
-        StartupManager.getInstance(project).runAfterOpened { isReady = true }
+    fun markReady() {
+        isReady = true
     }
 }

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DResourceHandler.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DResourceHandler.kt
@@ -169,7 +169,7 @@ class Model3DResourceHandler private constructor(
     companion object {
         private val LOG = Logger.getInstance(Model3DResourceHandler::class.java)
 
-        // CEF net error code returned via CefResourceSkipCallback on skip failure.
+        // CEF net error code set on the bytesSkipped LongRef to signal skip() failure.
         private const val ERR_FAILED = -2L
 
         /** A 404 handler. */

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DResourceHandler.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DResourceHandler.kt
@@ -78,7 +78,9 @@ class Model3DResourceHandler private constructor(
         response.status = 200
         response.setHeaderByName("Cache-Control", "no-cache", true)
         // responseLength is a 32-bit int; for anything larger (or unknown), pass
-        // -1 so CEF streams until read() signals completion.
+        // -1 so CEF streams until completion is signaled: read() returning
+        // false/0 bytes (in-process) or readResponse() doing the same (the
+        // out-of-process path).
         responseLength?.set(if (contentLength in 0..Int.MAX_VALUE.toLong()) contentLength.toInt() else -1)
     }
 

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DResourceHandler.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DResourceHandler.kt
@@ -33,6 +33,9 @@ class Model3DResourceHandler private constructor(
 
     private fun openStream() {
         val factory = streamFactory ?: return
+        // Guard against a repeated open()/processRequest() on the same handler
+        // leaking the previous stream.
+        closeStream()
         stream = try {
             BufferedInputStream(factory())
         } catch (e: Exception) {

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DResourceHandler.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DResourceHandler.kt
@@ -2,8 +2,12 @@ package ke.co.coterie.plugins.model3dviewer
 
 import com.intellij.openapi.diagnostic.Logger
 import org.cef.callback.CefCallback
-import org.cef.handler.CefResourceHandler
+import org.cef.callback.CefResourceReadCallback
+import org.cef.callback.CefResourceSkipCallback
+import org.cef.handler.CefResourceHandlerAdapter
+import org.cef.misc.BoolRef
 import org.cef.misc.IntRef
+import org.cef.misc.LongRef
 import org.cef.misc.StringRef
 import org.cef.network.CefRequest
 import org.cef.network.CefResponse
@@ -23,21 +27,36 @@ class Model3DResourceHandler private constructor(
     private val mimeType: String,
     private val contentLength: Long,
     private val streamFactory: (() -> InputStream)?,
-) : CefResourceHandler {
+) : CefResourceHandlerAdapter() {
 
     private var stream: InputStream? = null
 
-    override fun processRequest(request: CefRequest?, callback: CefCallback?): Boolean {
-        val factory = streamFactory
-        if (factory != null) {
-            stream = try {
-                BufferedInputStream(factory())
-            } catch (e: Exception) {
-                LOG.warn("Failed to open resource stream", e)
-                null
-            }
+    private fun openStream() {
+        val factory = streamFactory ?: return
+        stream = try {
+            BufferedInputStream(factory())
+        } catch (e: Exception) {
+            LOG.warn("Failed to open resource stream", e)
+            null
         }
+    }
+
+    /**
+     * Old JCEF API. Still required at runtime: the 2026.2+ out-of-process JCEF
+     * ("cef_server") bridges resource handlers over Thrift using processRequest/
+     * readResponse, not open/read. Deprecated, but not optional.
+     */
+    override fun processRequest(request: CefRequest?, callback: CefCallback?): Boolean {
+        openStream()
         callback?.Continue()
+        return true
+    }
+
+    /** New JCEF API (in-process path): open the resource and handle synchronously. */
+    override fun open(request: CefRequest?, handleRequest: BoolRef?, callback: CefCallback?): Boolean {
+        openStream()
+        // Handle the request immediately; getResponseHeaders is called next.
+        handleRequest?.set(true)
         return true
     }
 
@@ -56,16 +75,27 @@ class Model3DResourceHandler private constructor(
         response.status = 200
         response.setHeaderByName("Cache-Control", "no-cache", true)
         // responseLength is a 32-bit int; for anything larger (or unknown), pass
-        // -1 so CEF streams until readResponse signals completion.
+        // -1 so CEF streams until read() signals completion.
         responseLength?.set(if (contentLength in 0..Int.MAX_VALUE.toLong()) contentLength.toInt() else -1)
     }
 
+    /** New JCEF API (in-process path). */
+    override fun read(
+        dataOut: ByteArray?,
+        bytesToRead: Int,
+        bytesRead: IntRef?,
+        callback: CefResourceReadCallback?,
+    ): Boolean = readInto(dataOut, bytesToRead, bytesRead)
+
+    /** Old JCEF API. Required by the 2026.2+ out-of-process JCEF bridge (see [processRequest]). */
     override fun readResponse(
         dataOut: ByteArray?,
         bytesToRead: Int,
         bytesRead: IntRef?,
         callback: CefCallback?,
-    ): Boolean {
+    ): Boolean = readInto(dataOut, bytesToRead, bytesRead)
+
+    private fun readInto(dataOut: ByteArray?, bytesToRead: Int, bytesRead: IntRef?): Boolean {
         val s = stream
         if (s == null || dataOut == null) {
             bytesRead?.set(0)
@@ -89,6 +119,37 @@ class Model3DResourceHandler private constructor(
         }
     }
 
+    /** New JCEF API (2026.2+): skip forward in the stream (e.g. for range requests). */
+    override fun skip(bytesToSkip: Long, bytesSkipped: LongRef?, callback: CefResourceSkipCallback?): Boolean {
+        val s = stream
+        if (s == null || bytesToSkip < 0) {
+            bytesSkipped?.set(ERR_FAILED)
+            return false
+        }
+        return try {
+            var remaining = bytesToSkip
+            val scratch = ByteArray(8 * 1024)
+            while (remaining > 0) {
+                val skipped = s.skip(remaining)
+                if (skipped > 0) {
+                    remaining -= skipped
+                    continue
+                }
+                // skip() may return 0 without being at EOF; fall back to reading.
+                val toRead = minOf(remaining, scratch.size.toLong()).toInt()
+                val n = s.read(scratch, 0, toRead)
+                if (n <= 0) break
+                remaining -= n
+            }
+            bytesSkipped?.set(bytesToSkip - remaining)
+            true
+        } catch (e: Exception) {
+            LOG.warn("Failed while skipping resource", e)
+            bytesSkipped?.set(ERR_FAILED)
+            false
+        }
+    }
+
     override fun cancel() {
         closeStream()
     }
@@ -104,6 +165,9 @@ class Model3DResourceHandler private constructor(
 
     companion object {
         private val LOG = Logger.getInstance(Model3DResourceHandler::class.java)
+
+        // CEF net error code returned via CefResourceSkipCallback on skip failure.
+        private const val ERR_FAILED = -2L
 
         /** A 404 handler. */
         fun notFound(): Model3DResourceHandler = Model3DResourceHandler("text/plain", -1, null)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -82,6 +82,7 @@
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.compose</depends>
     <depends>com.intellij.modules.json</depends>
+    <depends>com.intellij.modules.jcef</depends>
 
     <resource-bundle>messages.MyMessageBundle</resource-bundle>
 
@@ -140,6 +141,8 @@
         <postStartupActivity implementation="ke.co.coterie.plugins.model3dviewer.ObjFileTypeStartupActivity"/>
         <!-- Sets initial glTF Structure tool window visibility for a restored glTF/GLB tab -->
         <postStartupActivity implementation="ke.co.coterie.plugins.model3dviewer.GltfStructureStartupActivity"/>
+        <!-- Marks the Got It tooltip state ready once the project has finished opening -->
+        <postStartupActivity implementation="ke.co.coterie.plugins.model3dviewer.Model3DJsonGotItStartupActivity"/>
 
         <!-- Tool window revealing the internal structure of the active glTF/GLB file.
              Hidden by default; shown only while a .glb/.gltf file is in focus. -->


### PR DESCRIPTION
## What

Migrates the plugin to **IntelliJ 2026.2 (build 262)** and adopts the new JCEF `CefResourceHandler` API, fixing the Marketplace binary-incompatibility that risked an `AbstractMethodError` (`open`/`read`/`skip` were unimplemented).

## Why the viewer was showing `ERR_FAILED`

2026.2 runs JCEF **out-of-process** (`cef_server`). Its Thrift bridge (`ClientHandlersImpl`) invokes the **deprecated** `processRequest`/`readResponse` methods over RPC — not the new `open`/`read`/`skip`. With only the new methods implemented, the adapter default `processRequest` returned `false`, so every request failed. The handler now implements **both** API sets.

## Changes

- **Platform bump:** 2026.2, Kotlin 2.4.10, intellij-platform 2.18.1, JVM toolchain 21; `sinceBuild`/`untilBuild` = `262` (drops older IDE support, as agreed).
- **JCEF dependency:** depend on bundled `com.intellij.modules.jcef` (JCEF left the base classpath) in `build.gradle.kts` + `plugin.xml`.
- **Resource handler:** extend `CefResourceHandlerAdapter`, implement new `open`/`read`/`skip` and deprecated `processRequest`/`readResponse` (runtime-required by out-of-process JCEF).
- **Verifier:** drop `DEPRECATED_API_USAGES` from `failureLevel` (the deprecated overrides are unavoidable); keep compatibility / scheduled-for-removal / invalid-plugin as failures.
- **Internal API:** replace `StartupManager.runAfterOpened` with a `ProjectActivity` (`Model3DJsonGotItStartupActivity`) + `markReady()`.
- **Deprecations:** `ReadAction.compute` -> `computeBlocking`; suppress Kotlin default-method bridge warnings via `-jvm-default=no-compatibility`.
- **CI:** publish the plugin-verifier report to the job summary and upload it as an artifact.

## Verification

- `verifyPlugin` -> **Compatible** against `IU-262.8665.258`.
- Full `build` succeeds.
- `runIde` (2026.2): the Threlte viewer loads and renders a `.glb` model — no `ERR_FAILED`.
