### PR TITLE
feat: support Community editions by dropping unused Compose dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "2.4.10"
     id("org.jetbrains.intellij.platform") version "2.18.1"
-    id("org.jetbrains.kotlin.plugin.compose") version "2.4.10"
     id("org.jetbrains.changelog") version "2.2.1"
 }
 
@@ -48,9 +47,6 @@ dependencies {
         // JCEF moved out of the platform core into its own bundled plugin in 2026.2;
         // it provides JBCefBrowser and the org.cef.* resource-handler API.
         bundledPlugin("com.intellij.modules.jcef")
-
-        composeUI()
-
     }
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -80,7 +80,6 @@
 
     <!-- Product and plugin compatibility requirements.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
-    <depends>com.intellij.modules.compose</depends>
     <depends>com.intellij.modules.json</depends>
     <depends>com.intellij.modules.jcef</depends>
 


### PR DESCRIPTION
## What

Adds support for **IntelliJ IDEA Community** and **PyCharm Community** by removing an unused Compose dependency.

## Why they were unsupported

The Marketplace derives supported products from `plugin.xml` dependencies. The plugin declared `<depends>com.intellij.modules.compose</depends>`, and `com.intellij.modules.compose` is only available in Ultimate/Professional editions. That excluded every Community edition, even though every paid IDE (IDEA Ultimate, PyCharm Pro, WebStorm, GoLand, PhpStorm, Rider, CLion, RubyMine, RustRover, DataGrip) was supported.

Compose was **never used anywhere in the plugin source**, so the dependency was pure dead weight blocking Community support.

## Changes

Removed all three Compose references:
- `id("org.jetbrains.kotlin.plugin.compose")` from the `plugins {}` block
- `composeUI()` from the platform dependencies
- `<depends>com.intellij.modules.compose</depends>` from `plugin.xml`

The remaining module dependencies (`json`, `jcef`) are available in Community editions.

## Verification

- `buildPlugin` succeeds.
- `verifyPlugin` -> **Compatible** against `IU-262.8665.258`.
- After this change the Marketplace "Products" list should add IntelliJ IDEA Community and PyCharm Community.

Note: Android Studio, MPS, JetBrains Client/Gateway, AppCode, and DataSpell remain unsupported for unrelated reasons (JCEF/platform differences); this PR targets the Community editions specifically.
