### PR TITLE
ci: publish to JetBrains Marketplace on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,15 +147,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      # ============================================================
-      # JetBrains Marketplace Publishing
-      # ============================================================
-      # Runs only when the "publish_marketplace" checkbox is enabled on the
-      # manual run. Uses the JETBRAINS_MARKETPLACE_TOKEN repository secret,
-      # mapped to the PUBLISH_TOKEN env var read by the publishPlugin task
-      # (see build.gradle.kts). Token management:
-      # https://plugins.jetbrains.com/author/me/tokens
-      # ============================================================
+      # Publish to the JetBrains Marketplace. Opt out per run via the
+      # publish_marketplace input. PUBLISH_TOKEN is read by the publishPlugin task.
       - name: Publish to JetBrains Marketplace
         if: ${{ steps.changelog.outputs.skipped == 'false' && inputs.publish_marketplace }}
         run: ./gradlew publishPlugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,16 @@ jobs:
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: ./gradlew verifyPlugin
 
+      # Publish to the JetBrains Marketplace before creating the GitHub Release
+      # so a publish failure doesn't leave a GitHub Release for a version that
+      # never reached the Marketplace. Opt out per run via the
+      # publish_marketplace input. PUBLISH_TOKEN is read by the publishPlugin task.
+      - name: Publish to JetBrains Marketplace
+        if: ${{ steps.changelog.outputs.skipped == 'false' && github.event.inputs.publish_marketplace == 'true' }}
+        run: ./gradlew publishPlugin
+        env:
+          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+
       - name: Create GitHub Release
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         uses: softprops/action-gh-release@v2
@@ -147,14 +157,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      # Publish to the JetBrains Marketplace. Opt out per run via the
-      # publish_marketplace input. PUBLISH_TOKEN is read by the publishPlugin task.
-      - name: Publish to JetBrains Marketplace
-        if: ${{ steps.changelog.outputs.skipped == 'false' && inputs.publish_marketplace }}
-        run: ./gradlew publishPlugin
-        env:
-          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
-
       - name: Summary
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: |
@@ -162,7 +164,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ steps.get-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Tag:** ${{ steps.get-version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Published to Marketplace:** ${{ inputs.publish_marketplace }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Published to Marketplace:** ${{ github.event.inputs.publish_marketplace }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Changelog" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.changelog.outputs.clean_changelog }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,18 +144,17 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # ============================================================
-      # JetBrains Marketplace Publishing (Uncomment when ready)
+      # JetBrains Marketplace Publishing
       # ============================================================
-      # Prerequisites:
-      # 1. Generate a token at: https://plugins.jetbrains.com/author/me/tokens
-      # 2. Add JETBRAINS_MARKETPLACE_TOKEN as a repository secret
-      # 3. Uncomment the step below
+      # Uses the JETBRAINS_MARKETPLACE_TOKEN repository secret, mapped to the
+      # PUBLISH_TOKEN env var read by the publishPlugin task (see build.gradle.kts).
+      # Token management: https://plugins.jetbrains.com/author/me/tokens
       # ============================================================
-      # - name: Publish to JetBrains Marketplace
-      #   if: ${{ steps.changelog.outputs.skipped == 'false' }}
-      #   run: ./gradlew publishPlugin
-      #   env:
-      #     PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+      - name: Publish to JetBrains Marketplace
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        run: ./gradlew publishPlugin
+        env:
+          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
 
       - name: Summary
         if: ${{ steps.changelog.outputs.skipped == 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,16 +133,6 @@ jobs:
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: ./gradlew verifyPlugin
 
-      # Publish to the JetBrains Marketplace before creating the GitHub Release
-      # so a publish failure doesn't leave a GitHub Release for a version that
-      # never reached the Marketplace. Opt out per run via the
-      # publish_marketplace input. PUBLISH_TOKEN is read by the publishPlugin task.
-      - name: Publish to JetBrains Marketplace
-        if: ${{ steps.changelog.outputs.skipped == 'false' && github.event.inputs.publish_marketplace == 'true' }}
-        run: ./gradlew publishPlugin
-        env:
-          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
-
       - name: Create GitHub Release
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         uses: softprops/action-gh-release@v2
@@ -156,6 +146,17 @@ jobs:
             build/distributions/*.zip
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Publish to the JetBrains Marketplace. Secondary to the tag/release flow:
+      # continue-on-error keeps a publish failure from failing the release, since
+      # a version can still be uploaded to the Marketplace manually. Opt out per
+      # run via the publish_marketplace input. PUBLISH_TOKEN is read by publishPlugin.
+      - name: Publish to JetBrains Marketplace
+        if: ${{ steps.changelog.outputs.skipped == 'false' && github.event.inputs.publish_marketplace == 'true' }}
+        continue-on-error: true
+        run: ./gradlew publishPlugin
+        env:
+          PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
 
       - name: Summary
         if: ${{ steps.changelog.outputs.skipped == 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
       # Publish to the JetBrains Marketplace. Opt out per run via the
       # publish_marketplace input. PUBLISH_TOKEN is read by the publishPlugin task.
       - name: Publish to JetBrains Marketplace
-        if: ${{ steps.changelog.outputs.skipped == 'false' && inputs.publish_marketplace }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' && inputs.publish_marketplace == 'true' }}
         run: ./gradlew publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
       # Publish to the JetBrains Marketplace. Opt out per run via the
       # publish_marketplace input. PUBLISH_TOKEN is read by the publishPlugin task.
       - name: Publish to JetBrains Marketplace
-        if: ${{ steps.changelog.outputs.skipped == 'false' && inputs.publish_marketplace == 'true' }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' && inputs.publish_marketplace }}
         run: ./gradlew publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,7 @@ jobs:
       # a version can still be uploaded to the Marketplace manually. Opt out per
       # run via the publish_marketplace input. PUBLISH_TOKEN is read by publishPlugin.
       - name: Publish to JetBrains Marketplace
+        id: publish_marketplace
         if: ${{ steps.changelog.outputs.skipped == 'false' && github.event.inputs.publish_marketplace == 'true' }}
         continue-on-error: true
         run: ./gradlew publishPlugin
@@ -165,7 +166,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ steps.get-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Tag:** ${{ steps.get-version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Published to Marketplace:** ${{ github.event.inputs.publish_marketplace }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Published to Marketplace:** ${{ steps.publish_marketplace.outcome == 'success' && 'yes' || (steps.publish_marketplace.outcome == 'failure' && 'failed (publish manually)' || 'no') }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Changelog" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.changelog.outputs.clean_changelog }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
           - patch
           - minor
           - major
+      publish_marketplace:
+        description: "Also publish this release to the JetBrains Marketplace."
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -146,12 +150,14 @@ jobs:
       # ============================================================
       # JetBrains Marketplace Publishing
       # ============================================================
-      # Uses the JETBRAINS_MARKETPLACE_TOKEN repository secret, mapped to the
-      # PUBLISH_TOKEN env var read by the publishPlugin task (see build.gradle.kts).
-      # Token management: https://plugins.jetbrains.com/author/me/tokens
+      # Runs only when the "publish_marketplace" checkbox is enabled on the
+      # manual run. Uses the JETBRAINS_MARKETPLACE_TOKEN repository secret,
+      # mapped to the PUBLISH_TOKEN env var read by the publishPlugin task
+      # (see build.gradle.kts). Token management:
+      # https://plugins.jetbrains.com/author/me/tokens
       # ============================================================
       - name: Publish to JetBrains Marketplace
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' && inputs.publish_marketplace }}
         run: ./gradlew publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
@@ -163,6 +169,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ steps.get-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Tag:** ${{ steps.get-version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Published to Marketplace:** ${{ inputs.publish_marketplace }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Changelog" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.changelog.outputs.clean_changelog }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What

Enables automatic JetBrains Marketplace publishing on release, gated by a checkbox.

The Release workflow builds, verifies, and creates a GitHub release, but the Marketplace publish step was commented out, so new versions had to be uploaded manually. This activates it and adds an opt-out.

## Details

- Runs `./gradlew publishPlugin`.
- `PUBLISH_TOKEN` is mapped from the `JETBRAINS_MARKETPLACE_TOKEN` repository secret.
- `build.gradle.kts` reads `PUBLISH_TOKEN` via `publishing { token = providers.environmentVariable("PUBLISH_TOKEN") }`.
- New `publish_marketplace` boolean `workflow_dispatch` input (checkbox, default enabled) controls whether a release also publishes to the Marketplace. The publish step and the run summary respect it.
- Publishing is gated by the same `steps.changelog.outputs.skipped == 'false'` condition as the other release steps.

## Effect

A tagged release publishes the plugin to the Marketplace automatically when the checkbox is enabled, replacing the manual upload. Relates to #57.
