### PR TITLE
New plugin logo and file-type icons

### DIFF
--- a/src/main/resources/META-INF/pluginIcon.svg
+++ b/src/main/resources/META-INF/pluginIcon.svg
@@ -1,8 +1,15 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#55595C">
-    <path d="M12 17C12.5523 17 13 16.5523 13 16C13 15.4477 12.5523 15 12 15C11.4477 15 11 15.4477 11 16C11 16.5523 11.4477 17 12 17Z" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M21 7.35304L21 16.647C21 16.8649 20.8819 17.0656 20.6914 17.1715L12.2914 21.8381C12.1102 21.9388 11.8898 21.9388 11.7086 21.8381L3.30861 17.1715C3.11814 17.0656 3 16.8649 3 16.647L2.99998 7.35304C2.99998 7.13514 3.11812 6.93437 3.3086 6.82855L11.7086 2.16188C11.8898 2.06121 12.1102 2.06121 12.2914 2.16188L20.6914 6.82855C20.8818 6.93437 21 7.13514 21 7.35304Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M20.5 16.7222L12.2914 12.1618C12.1102 12.0612 11.8898 12.0612 11.7086 12.1618L3.5 16.7222" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.52844 7.29363L11.7086 11.8382C11.8898 11.9388 12.1102 11.9388 12.2914 11.8382L20.5 7.27783" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 3L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 19.5V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="4.2" cy="12" rx="2.2" ry="3.2" fill="#CCCC33"/>
+  <ellipse cx="19.8" cy="12" rx="2.2" ry="3.2" fill="none" stroke="#47A3D1" stroke-width="1.2"/>
+  <path d="M12 5 C8 5, 5.5 7.5, 5.5 11 C5.5 15.5, 8.5 19, 12 19 Z" fill="#CCCC33"/>
+  <g stroke="#47A3D1" stroke-width="1.2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 5 C16 5, 18.5 7.5, 18.5 11 C18.5 15.5, 15.5 19, 12 19"/>
+    <path d="M12 9 C14.5 8.5, 16.5 9, 17.4 10.2"/>
+    <path d="M13.2 12.2 A1.4 1.6 0 0 1 15.6 12.2"/>
+    <path d="M13 16 C14.5 16.8, 16 16.5, 17 15.4"/>
+  </g>
+  <g stroke="#47A3D1" stroke-width="1.2" fill="none" stroke-linecap="round">
+    <path d="M12 5 L12 19"/>
+    <path d="M12 9 C9.5 8.5, 7.5 9, 6.6 10.2"/>
+  </g>
 </svg>

--- a/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,8 +1,15 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#CED0D6">
-    <path d="M12 17C12.5523 17 13 16.5523 13 16C13 15.4477 12.5523 15 12 15C11.4477 15 11 15.4477 11 16C11 16.5523 11.4477 17 12 17Z" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M21 7.35304L21 16.647C21 16.8649 20.8819 17.0656 20.6914 17.1715L12.2914 21.8381C12.1102 21.9388 11.8898 21.9388 11.7086 21.8381L3.30861 17.1715C3.11814 17.0656 3 16.8649 3 16.647L2.99998 7.35304C2.99998 7.13514 3.11812 6.93437 3.3086 6.82855L11.7086 2.16188C11.8898 2.06121 12.1102 2.06121 12.2914 2.16188L20.6914 6.82855C20.8818 6.93437 21 7.13514 21 7.35304Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M20.5 16.7222L12.2914 12.1618C12.1102 12.0612 11.8898 12.0612 11.7086 12.1618L3.5 16.7222" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.52844 7.29363L11.7086 11.8382C11.8898 11.9388 12.1102 11.9388 12.2914 11.8382L20.5 7.27783" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 3L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 19.5V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="4.2" cy="12" rx="2.2" ry="3.2" fill="#CCCC33"/>
+  <ellipse cx="19.8" cy="12" rx="2.2" ry="3.2" fill="none" stroke="#47A3D1" stroke-width="1.2"/>
+  <path d="M12 5 C8 5, 5.5 7.5, 5.5 11 C5.5 15.5, 8.5 19, 12 19 Z" fill="#CCCC33"/>
+  <g stroke="#47A3D1" stroke-width="1.2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 5 C16 5, 18.5 7.5, 18.5 11 C18.5 15.5, 15.5 19, 12 19"/>
+    <path d="M12 9 C14.5 8.5, 16.5 9, 17.4 10.2"/>
+    <path d="M13.2 12.2 A1.4 1.6 0 0 1 15.6 12.2"/>
+    <path d="M13 16 C14.5 16.8, 16 16.5, 17 15.4"/>
+  </g>
+  <g stroke="#47A3D1" stroke-width="1.2" fill="none" stroke-linecap="round">
+    <path d="M12 5 L12 19"/>
+    <path d="M12 9 C9.5 8.5, 7.5 9, 6.6 10.2"/>
+  </g>
 </svg>

--- a/src/main/resources/icons/glb_dark.svg
+++ b/src/main/resources/icons/glb_dark.svg
@@ -1,8 +1,5 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#CED0D6">
-    <path d="M12 17C12.5523 17 13 16.5523 13 16C13 15.4477 12.5523 15 12 15C11.4477 15 11 15.4477 11 16C11 16.5523 11.4477 17 12 17Z" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M21 7.35304L21 16.647C21 16.8649 20.8819 17.0656 20.6914 17.1715L12.2914 21.8381C12.1102 21.9388 11.8898 21.9388 11.7086 21.8381L3.30861 17.1715C3.11814 17.0656 3 16.8649 3 16.647L2.99998 7.35304C2.99998 7.13514 3.11812 6.93437 3.3086 6.82855L11.7086 2.16188C11.8898 2.06121 12.1102 2.06121 12.2914 2.16188L20.6914 6.82855C20.8818 6.93437 21 7.13514 21 7.35304Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M20.5 16.7222L12.2914 12.1618C12.1102 12.0612 11.8898 12.0612 11.7086 12.1618L3.5 16.7222" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.52844 7.29363L11.7086 11.8382C11.8898 11.9388 12.1102 11.9388 12.2914 11.8382L20.5 7.27783" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 3L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 19.5V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 3 L20.5 7.5 L12 12 L3.5 7.5 Z" fill="#5AC8C2"/>
+  <path d="M3.5 7.5 L12 12 L12 21 L3.5 16.5 Z" fill="#2AA6A0"/>
+  <path d="M20.5 7.5 L12 12 L12 21 L20.5 16.5 Z" fill="#1E8480"/>
 </svg>

--- a/src/main/resources/icons/glb_light.svg
+++ b/src/main/resources/icons/glb_light.svg
@@ -1,8 +1,5 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#3C3F41">
-    <path d="M12 17C12.5523 17 13 16.5523 13 16C13 15.4477 12.5523 15 12 15C11.4477 15 11 15.4477 11 16C11 16.5523 11.4477 17 12 17Z" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M21 7.35304L21 16.647C21 16.8649 20.8819 17.0656 20.6914 17.1715L12.2914 21.8381C12.1102 21.9388 11.8898 21.9388 11.7086 21.8381L3.30861 17.1715C3.11814 17.0656 3 16.8649 3 16.647L2.99998 7.35304C2.99998 7.13514 3.11812 6.93437 3.3086 6.82855L11.7086 2.16188C11.8898 2.06121 12.1102 2.06121 12.2914 2.16188L20.6914 6.82855C20.8818 6.93437 21 7.13514 21 7.35304Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M20.5 16.7222L12.2914 12.1618C12.1102 12.0612 11.8898 12.0612 11.7086 12.1618L3.5 16.7222" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.52844 7.29363L11.7086 11.8382C11.8898 11.9388 12.1102 11.9388 12.2914 11.8382L20.5 7.27783" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 3L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 19.5V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 3 L20.5 7.5 L12 12 L3.5 7.5 Z" fill="#5AC8C2"/>
+  <path d="M3.5 7.5 L12 12 L12 21 L3.5 16.5 Z" fill="#2AA6A0"/>
+  <path d="M20.5 7.5 L12 12 L12 21 L20.5 16.5 Z" fill="#1E8480"/>
 </svg>

--- a/src/main/resources/icons/gltf_dark.svg
+++ b/src/main/resources/icons/gltf_dark.svg
@@ -1,8 +1,7 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#589DF6">
-    <path d="M12 17C12.5523 17 13 16.5523 13 16C13 15.4477 12.5523 15 12 15C11.4477 15 11 15.4477 11 16C11 16.5523 11.4477 17 12 17Z" fill="#589DF6" stroke="#589DF6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M21 7.35304L21 16.647C21 16.8649 20.8819 17.0656 20.6914 17.1715L12.2914 21.8381C12.1102 21.9388 11.8898 21.9388 11.7086 21.8381L3.30861 17.1715C3.11814 17.0656 3 16.8649 3 16.647L2.99998 7.35304C2.99998 7.13514 3.11812 6.93437 3.3086 6.82855L11.7086 2.16188C11.8898 2.06121 12.1102 2.06121 12.2914 2.16188L20.6914 6.82855C20.8818 6.93437 21 7.13514 21 7.35304Z" stroke="#589DF6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M20.5 16.7222L12.2914 12.1618C12.1102 12.0612 11.8898 12.0612 11.7086 12.1618L3.5 16.7222" stroke="#589DF6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.52844 7.29363L11.7086 11.8382C11.8898 11.9388 12.1102 11.9388 12.2914 11.8382L20.5 7.27783" stroke="#589DF6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 3L12 12" stroke="#589DF6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 19.5V22" stroke="#589DF6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#3B82F6" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round" fill="none">
+    <path d="M12 3 L20.5 7.5 L20.5 16.5 L12 21 L3.5 16.5 L3.5 7.5 Z"/>
+    <path d="M12 3 L12 12 M12 12 L20.5 7.5 M12 12 L3.5 7.5"/>
+    <path d="M12 12 L12 21"/>
+  </g>
 </svg>

--- a/src/main/resources/icons/gltf_light.svg
+++ b/src/main/resources/icons/gltf_light.svg
@@ -1,8 +1,7 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#2B6CB0">
-    <path d="M12 17C12.5523 17 13 16.5523 13 16C13 15.4477 12.5523 15 12 15C11.4477 15 11 15.4477 11 16C11 16.5523 11.4477 17 12 17Z" fill="#2B6CB0" stroke="#2B6CB0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M21 7.35304L21 16.647C21 16.8649 20.8819 17.0656 20.6914 17.1715L12.2914 21.8381C12.1102 21.9388 11.8898 21.9388 11.7086 21.8381L3.30861 17.1715C3.11814 17.0656 3 16.8649 3 16.647L2.99998 7.35304C2.99998 7.13514 3.11812 6.93437 3.3086 6.82855L11.7086 2.16188C11.8898 2.06121 12.1102 2.06121 12.2914 2.16188L20.6914 6.82855C20.8818 6.93437 21 7.13514 21 7.35304Z" stroke="#2B6CB0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M20.5 16.7222L12.2914 12.1618C12.1102 12.0612 11.8898 12.0612 11.7086 12.1618L3.5 16.7222" stroke="#2B6CB0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.52844 7.29363L11.7086 11.8382C11.8898 11.9388 12.1102 11.9388 12.2914 11.8382L20.5 7.27783" stroke="#2B6CB0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 3L12 12" stroke="#2B6CB0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 19.5V22" stroke="#2B6CB0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#3B82F6" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round" fill="none">
+    <path d="M12 3 L20.5 7.5 L20.5 16.5 L12 21 L3.5 16.5 L3.5 7.5 Z"/>
+    <path d="M12 3 L12 12 M12 12 L20.5 7.5 M12 12 L3.5 7.5"/>
+    <path d="M12 12 L12 21"/>
+  </g>
 </svg>

--- a/src/main/resources/icons/obj_dark.svg
+++ b/src/main/resources/icons/obj_dark.svg
@@ -1,8 +1,5 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#F6AD55">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#F6AD55" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 2C12 2 16 6 16 12C16 18 12 22 12 22" stroke="#F6AD55" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 2C12 2 8 6 8 12C8 18 12 22 12 22" stroke="#F6AD55" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3 12H21" stroke="#F6AD55" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.5 7H20.5" stroke="#F6AD55" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.5 17H20.5" stroke="#F6AD55" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="16" height="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="9" fill="#E8833A"/>
+  <ellipse cx="9" cy="8.4" rx="2" ry="2.6" fill="#F4A968" opacity="0.8" transform="rotate(-25 9 8.4)"/>
+  <path d="M3.3 12 H20.7 M12 3 A5 9 0 0 0 12 21" stroke="#8A3D0B" stroke-width="1.4" fill="none" opacity="0.85" stroke-linecap="round"/>
 </svg>

--- a/src/main/resources/icons/obj_light.svg
+++ b/src/main/resources/icons/obj_light.svg
@@ -1,8 +1,5 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#DD6B20">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#DD6B20" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 2C12 2 16 6 16 12C16 18 12 22 12 22" stroke="#DD6B20" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 2C12 2 8 6 8 12C8 18 12 22 12 22" stroke="#DD6B20" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3 12H21" stroke="#DD6B20" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.5 7H20.5" stroke="#DD6B20" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.5 17H20.5" stroke="#DD6B20" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="16" height="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="9" fill="#E8833A"/>
+  <ellipse cx="9" cy="8.4" rx="2" ry="2.6" fill="#F4A968" opacity="0.8" transform="rotate(-25 9 8.4)"/>
+  <path d="M3.3 12 H20.7 M12 3 A5 9 0 0 0 12 21" stroke="#8A3D0B" stroke-width="1.4" fill="none" opacity="0.85" stroke-linecap="round"/>
 </svg>

--- a/src/main/resources/icons/pluginIcon_dark.svg
+++ b/src/main/resources/icons/pluginIcon_dark.svg
@@ -1,8 +1,0 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#CED0D6">
-    <path d="M12 17C12.5523 17 13 16.5523 13 16C13 15.4477 12.5523 15 12 15C11.4477 15 11 15.4477 11 16C11 16.5523 11.4477 17 12 17Z" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M21 7.35304L21 16.647C21 16.8649 20.8819 17.0656 20.6914 17.1715L12.2914 21.8381C12.1102 21.9388 11.8898 21.9388 11.7086 21.8381L3.30861 17.1715C3.11814 17.0656 3 16.8649 3 16.647L2.99998 7.35304C2.99998 7.13514 3.11812 6.93437 3.3086 6.82855L11.7086 2.16188C11.8898 2.06121 12.1102 2.06121 12.2914 2.16188L20.6914 6.82855C20.8818 6.93437 21 7.13514 21 7.35304Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M20.5 16.7222L12.2914 12.1618C12.1102 12.0612 11.8898 12.0612 11.7086 12.1618L3.5 16.7222" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.52844 7.29363L11.7086 11.8382C11.8898 11.9388 12.1102 11.9388 12.2914 11.8382L20.5 7.27783" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 3L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 19.5V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/src/main/resources/icons/pluginIcon_light.svg
+++ b/src/main/resources/icons/pluginIcon_light.svg
@@ -1,8 +1,0 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#CED0D6">
-    <path d="M12 17C12.5523 17 13 16.5523 13 16C13 15.4477 12.5523 15 12 15C11.4477 15 11 15.4477 11 16C11 16.5523 11.4477 17 12 17Z" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M21 7.35304L21 16.647C21 16.8649 20.8819 17.0656 20.6914 17.1715L12.2914 21.8381C12.1102 21.9388 11.8898 21.9388 11.7086 21.8381L3.30861 17.1715C3.11814 17.0656 3 16.8649 3 16.647L2.99998 7.35304C2.99998 7.13514 3.11812 6.93437 3.3086 6.82855L11.7086 2.16188C11.8898 2.06121 12.1102 2.06121 12.2914 2.16188L20.6914 6.82855C20.8818 6.93437 21 7.13514 21 7.35304Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M20.5 16.7222L12.2914 12.1618C12.1102 12.0612 11.8898 12.0612 11.7086 12.1618L3.5 16.7222" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.52844 7.29363L11.7086 11.8382C11.8898 11.9388 12.1102 11.9388 12.2914 11.8382L20.5 7.27783" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 3L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 19.5V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/src/main/resources/icons/stl_dark.svg
+++ b/src/main/resources/icons/stl_dark.svg
@@ -1,8 +1,5 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#68D391">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#68D391" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 2C12 2 16 6 16 12C16 18 12 22 12 22" stroke="#68D391" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 2C12 2 8 6 8 12C8 18 12 22 12 22" stroke="#68D391" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3 12H21" stroke="#68D391" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.5 7H20.5" stroke="#68D391" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.5 17H20.5" stroke="#68D391" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 3 L21 18 L3 18 Z" fill="#3AA76D"/>
+  <path d="M12 3 L12 18 L3 18 Z" fill="#2F855A"/>
+  <path d="M12 3 L7.5 18 M12 3 L16.5 18 M4.5 15 L19.5 15" stroke="#0F5132" stroke-width="1.1" stroke-linejoin="round" fill="none" opacity="0.55"/>
 </svg>

--- a/src/main/resources/icons/stl_light.svg
+++ b/src/main/resources/icons/stl_light.svg
@@ -1,8 +1,5 @@
-<svg width="16px" height="16px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#2F855A">
-    <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#2F855A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 2C12 2 16 6 16 12C16 18 12 22 12 22" stroke="#2F855A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 2C12 2 8 6 8 12C8 18 12 22 12 22" stroke="#2F855A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3 12H21" stroke="#2F855A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.5 7H20.5" stroke="#2F855A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M3.5 17H20.5" stroke="#2F855A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 3 L21 18 L3 18 Z" fill="#3AA76D"/>
+  <path d="M12 3 L12 18 L3 18 Z" fill="#2F855A"/>
+  <path d="M12 3 L7.5 18 M12 3 L16.5 18 M4.5 15 L19.5 15" stroke="#0F5132" stroke-width="1.1" stroke-linejoin="round" fill="none" opacity="0.55"/>
 </svg>


### PR DESCRIPTION
Restores the finalized branding onto main (it was pushed to the #59 branch after that PR's squash merge, so it never landed).

## Plugin logo
Half-solid / half-wireframe monkey (Suzanne) that reads as a 3D model preview:
- Solid half: amber `#CCCC33`
- Wireframe half: cyan `#47A3D1`
- Hues picked from the color wheel for a harmonious solid-vs-wireframe split; legible on light and dark themes.

## File-type icons
One distinct glyph per format (New UI friendly):
- **GLB** solid cube
- **glTF** wireframe cube (source form of GLB)
- **STL** faceted triangle mesh
- **OBJ** shaded globe

Fixes the prior look where OBJ and STL were both globes.

> Design exploration archive lives on the `docs/brand-assets` branch (`docs/branding/`).