### PR TITLE
fix: glTF JSON panel follows the IDE editor theme

### DIFF
--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DSchemeHandlerFactory.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DSchemeHandlerFactory.kt
@@ -104,10 +104,10 @@ class Model3DSchemeHandlerFactory : CefSchemeHandlerFactory {
             autoRotate: Boolean,
             background: String
         ): String {
-            val type = modelPath.substringAfterLast('/').substringAfterLast('.', "").lowercase()
+            val type = enc(modelPath.substringAfterLast('/').substringAfterLast('.', "").lowercase())
             val modelParam = enc("m/$token/$modelPath")
             return "http://$VIEWER_HOST/index.html?model=$modelParam&type=$type" +
-                "&wireframe=$wireframe&autorotate=$autoRotate&background=$background"
+                "&wireframe=$wireframe&autorotate=$autoRotate&background=${enc(background)}"
         }
 
         private fun enc(value: String): String =

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
@@ -1,7 +1,12 @@
 package ke.co.coterie.plugins.model3dviewer
 
+import com.intellij.ide.ui.LafManager
+import com.intellij.ide.ui.LafManagerListener
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.editor.colors.EditorColorsListener
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.ScrollType
 import com.intellij.openapi.fileEditor.FileEditor
@@ -88,6 +93,12 @@ class Model3DTextEditorWithPreview(
             // populate the document from the background task below.
             (editor.editor as? EditorEx)?.isViewer = true
 
+            // This in-memory *.json viewer otherwise renders with a fixed (light)
+            // color scheme regardless of the IDE theme, so it looks out of place
+            // next to the 3D preview and the rest of a dark IDE. Bind it to the
+            // editor scheme that matches the current UI theme and keep it in sync.
+            bindEditorToIdeTheme(editor)
+
             // Highlight the corresponding materials in the 3D preview as the caret moves
             // or the selection changes. Listeners are disposed together with the editor.
             val highlightListener = GltfMaterialHighlightListener(project, file, editor.editor)
@@ -96,6 +107,24 @@ class Model3DTextEditorWithPreview(
 
             loadJsonAsync(project, file, editor, highlightListener)
             return editor
+        }
+
+        /**
+         * Bind [editor]'s color scheme to the one matching the current IDE UI theme
+         * and re-apply it whenever the theme or global editor scheme changes, so the
+         * in-memory glTF JSON view tracks the IDE instead of staying on a fixed
+         * (light) scheme. Subscriptions are tied to the editor's disposal.
+         */
+        private fun bindEditorToIdeTheme(editor: TextEditor) {
+            val ex = editor.editor as? EditorEx ?: return
+            fun apply() {
+                val scheme: EditorColorsScheme = EditorColorsManager.getInstance().schemeForCurrentUITheme
+                if (ex.colorsScheme !== scheme) ex.colorsScheme = scheme
+            }
+            apply()
+            val connection = ApplicationManager.getApplication().messageBus.connect(editor)
+            connection.subscribe(EditorColorsManager.TOPIC, EditorColorsListener { apply() })
+            connection.subscribe(LafManagerListener.TOPIC, LafManagerListener { _: LafManager -> apply() })
         }
 
         private fun loadJsonAsync(

--- a/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
+++ b/src/main/kotlin/ke/co/coterie/plugins/model3dviewer/Model3DTextEditorWithPreview.kt
@@ -118,13 +118,20 @@ class Model3DTextEditorWithPreview(
         private fun bindEditorToIdeTheme(editor: TextEditor) {
             val ex = editor.editor as? EditorEx ?: return
             fun apply() {
+                if (ex.isDisposed) return
                 val scheme: EditorColorsScheme = EditorColorsManager.getInstance().schemeForCurrentUITheme
                 if (ex.colorsScheme !== scheme) ex.colorsScheme = scheme
             }
+            // Theme/scheme change callbacks are not guaranteed to run on the EDT, and
+            // mutating editor UI state off-EDT is unsafe; marshal onto the EDT (the
+            // apply() guards against a disposed editor). The initial call already runs
+            // on the EDT during editor creation.
+            fun applyOnEdt() =
+                ApplicationManager.getApplication().invokeLater({ apply() }, ModalityState.any())
             apply()
             val connection = ApplicationManager.getApplication().messageBus.connect(editor)
-            connection.subscribe(EditorColorsManager.TOPIC, EditorColorsListener { apply() })
-            connection.subscribe(LafManagerListener.TOPIC, LafManagerListener { _: LafManager -> apply() })
+            connection.subscribe(EditorColorsManager.TOPIC, EditorColorsListener { applyOnEdt() })
+            connection.subscribe(LafManagerListener.TOPIC, LafManagerListener { _: LafManager -> applyOnEdt() })
         }
 
         private fun loadJsonAsync(


### PR DESCRIPTION
## glTF JSON panel theme
### Problem
When viewing a glTF/GLB file, the read-only JSON side of the split editor rendered with a fixed light color scheme regardless of the IDE theme, so it looked out of place next to the 3D preview and the rest of a dark IDE (visible in the marketplace screenshots).

### Fix
The JSON side is an in-memory `*.json` viewer editor; it was not tracking the IDE theme. `createJsonTextEditor` now binds the editor's color scheme to the one matching the current UI theme and re-applies it when the theme or global editor scheme changes (subscriptions tied to the editor's disposal), so it matches the IDE like any normal editor.

## Follow-up: URL-encode viewer query params
Addresses a review note from #70: `viewerUrl` now URL-encodes the `type` and `background` query params (like `model`) instead of concatenating them raw, for consistency and robustness. Not an active bug today (both are controlled values), but it hardens the builder.

## Testing
`compileKotlin` clean. Verified in the sandbox: on a dark IDE, reopening a glTF file now shows the JSON panel in the dark theme matching the IDE.
